### PR TITLE
Update giraffe template README to note that you cannot use IIS Express

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,9 @@ If you add this source to your NuGet CLI or project settings then you can pull u
 
 ## Using Visual Studio
 
-The basic giraffe template doesn't work with `IIS Express` which may be the default IIS used by Visual Studio 2017 to build & publish your application. Make sure to change your drop-down (the top of your window, next to the other Configuration Manager settings) IIS setting to be the name of your project and *NOT* `IIS Express`. For more information, check out: https://github.com/giraffe-fsharp/Giraffe/issues/264
+The basic giraffe template doesn't work with `IIS Express` which may be the default IIS used by Visual Studio 2017 to build & publish your application. Make sure to change your drop-down (the top of your window, next to the other Configuration Manager settings) IIS setting to be the name of your project and *NOT* `IIS Express`. Example:
+
+![](https://user-images.githubusercontent.com/3818802/39714515-5535b446-51f8-11e8-9b76-9c89a3e70eea.png)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ https://ci.appveyor.com/nuget/giraffe-template
 
 If you add this source to your NuGet CLI or project settings then you can pull unofficial NuGet packages for quick feature testing or urgent hot fixes.
 
+## Using Visual Studio
+
+The basic giraffe template doesn't work with `IIS Express` which may be the default IIS used by Visual Studio 2017 to build & publish your application. Make sure to change your drop-down (the top of your window, next to the other Configuration Manager settings) IIS setting to be the name of your project and *NOT* `IIS Express`. For more information, check out: https://github.com/giraffe-fsharp/Giraffe/issues/264
+
 ## Contributing
 
 Please use the `./build.ps1` PowerShell script to build and test the Giraffe template before submitting a PR.


### PR DESCRIPTION
In response to https://github.com/giraffe-fsharp/giraffe-template/issues/15

Hopefully this saves more noobs hilarity.