### PR TITLE
Add App suffix to assembly name to avoid recursive reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -294,3 +294,6 @@ __pycache__/
 #custom
 
 .temp
+
+#Ionide
+.ionide

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "projects": [ "src", "tests" ],
     "sdk": {
-      "version": "2.1.403"
+      "version": "2.2.401"
     }
 }

--- a/src/content/DotLiquid/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
+++ b/src/content/DotLiquid/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <DebugType>portable</DebugType>
-    <AssemblyName>AppNamePlaceholder</AssemblyName>
+    <AssemblyName>AppNamePlaceholder.App</AssemblyName>
     <OutputType>Exe</OutputType>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
   </PropertyGroup>

--- a/src/content/DotLiquid/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
+++ b/src/content/DotLiquid/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UsePaket)' == false OR '$(UsePaket)' == ''">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Giraffe" Version="3.4.*" />
     <PackageReference Include="Giraffe.DotLiquid" Version="1.2.*" />
     <PackageReference Include="TaskBuilder.fs" Version="2.1.*" />

--- a/src/content/DotLiquid/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
+++ b/src/content/DotLiquid/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
@@ -5,7 +5,7 @@
 
   <ItemGroup Condition="'$(UsePaket)' == false OR '$(UsePaket)' == ''">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.*" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.*" />
     <PackageReference Include="xunit" Version="2.4.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.*" />

--- a/src/content/Giraffe/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
+++ b/src/content/Giraffe/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <DebugType>portable</DebugType>
-    <AssemblyName>AppNamePlaceholder</AssemblyName>
+    <AssemblyName>AppNamePlaceholder.App</AssemblyName>
     <OutputType>Exe</OutputType>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
   </PropertyGroup>

--- a/src/content/Giraffe/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
+++ b/src/content/Giraffe/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UsePaket)' == false OR '$(UsePaket)' == ''">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Giraffe" Version="3.4.*" />
     <PackageReference Include="TaskBuilder.fs" Version="2.1.*" />
   </ItemGroup>

--- a/src/content/Giraffe/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
+++ b/src/content/Giraffe/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
@@ -5,7 +5,7 @@
 
   <ItemGroup Condition="'$(UsePaket)' == false OR '$(UsePaket)' == ''">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.*" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.*" />
     <PackageReference Include="xunit" Version="2.4.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.*" />

--- a/src/content/None/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
+++ b/src/content/None/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <DebugType>portable</DebugType>
-    <AssemblyName>AppNamePlaceholder</AssemblyName>
+    <AssemblyName>AppNamePlaceholder.App</AssemblyName>
     <OutputType>Exe</OutputType>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
   </PropertyGroup>

--- a/src/content/None/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
+++ b/src/content/None/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UsePaket)' == false OR '$(UsePaket)' == ''">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Giraffe" Version="3.4.*" />
     <PackageReference Include="TaskBuilder.fs" Version="2.1.*" />
   </ItemGroup>

--- a/src/content/None/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
+++ b/src/content/None/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
@@ -5,7 +5,7 @@
 
   <ItemGroup Condition="'$(UsePaket)' == false OR '$(UsePaket)' == ''">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.*" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.*" />
     <PackageReference Include="xunit" Version="2.4.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.*" />

--- a/src/content/Razor/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
+++ b/src/content/Razor/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <DebugType>portable</DebugType>
-    <AssemblyName>AppNamePlaceholder</AssemblyName>
+    <AssemblyName>AppNamePlaceholder.App</AssemblyName>
     <OutputType>Exe</OutputType>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
   </PropertyGroup>

--- a/src/content/Razor/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
+++ b/src/content/Razor/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UsePaket)' == false OR '$(UsePaket)' == ''">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Giraffe" Version="3.4.*" />
     <PackageReference Include="Giraffe.Razor" Version="2.0.*" />
     <PackageReference Include="TaskBuilder.fs" Version="2.1.*" />

--- a/src/content/Razor/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
+++ b/src/content/Razor/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
@@ -6,7 +6,7 @@
 
   <ItemGroup Condition="'$(UsePaket)' == false OR '$(UsePaket)' == ''">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.*" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.*" />
     <PackageReference Include="xunit" Version="2.4.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.*" />

--- a/src/giraffe-template.nuspec
+++ b/src/giraffe-template.nuspec
@@ -2,7 +2,7 @@
 <package>
     <metadata>
         <id>giraffe-template</id>
-        <version>0.20.0</version>
+        <version>0.20.1</version>
         <title>Giraffe Template for dotnet-new</title>
         <summary>A dotnet-new template for Giraffe web applications.</summary>
         <description>A dotnet-new template for Giraffe web applications.</description>


### PR DESCRIPTION
I'm not sure how to test this, but if I correctly understand how this works, this PR should fix #27.