### PR TITLE
Upgrade Giraffe version and use dotnet 3.1 LTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -267,6 +267,9 @@ paket-files/
 .idea/
 *.sln.iml
 
+# Ionide VS Code
+.ionide/
+
 # CodeRush
 .cr/
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+## 0.21.0
+
+- Updated Giraffe to version 4.0.x
+- Set .NET 3.1 LTS as Default
+- Fix build warnings
+
 ## 0.20.0
 
 - Added shebang and fixed shellcheck warnings

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 0.1.0-{build}
-image: Visual Studio 2017
+image: Visual Studio 2019
 environment:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 init:
   - git config --global core.autocrlf true
 install:
-  - ps: .\.psscripts\install-dotnet.ps1
+  - ps: .\.psscripts\install-dotnet.ps1 -SdkVersions "3.1.300"
 build: off
 build_script:
   - ps: .\build.ps1

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "projects": [ "src", "tests" ],
     "sdk": {
-      "version": "2.1.403"
+      "version": "3.1"
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,8 @@
 {
     "projects": [ "src", "tests" ],
     "sdk": {
-      "version": "3.1"
+        "version": "3.1.100",
+        "rollForward": "latestMajor",
+        "allowPrerelease": false
     }
 }

--- a/src/content/DotLiquid/paket.dependencies
+++ b/src/content/DotLiquid/paket.dependencies
@@ -1,7 +1,6 @@
 storage: none
 source https://api.nuget.org/v3/index.json
 
-nuget Microsoft.AspNetCore.App
 nuget Giraffe
 nuget Giraffe.DotLiquid
 nuget Microsoft.NET.Test.Sdk

--- a/src/content/DotLiquid/paket.lock
+++ b/src/content/DotLiquid/paket.lock
@@ -23,10 +23,10 @@ NUGET
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       System.ValueTuple (>= 4.4) - restriction: >= net461
-    Microsoft.AspNet.WebApi.Client (5.2.6) - restriction: >= netcoreapp3.0
+    Microsoft.AspNet.WebApi.Client (5.2.6) - restriction: >= netcoreapp3.1
       Newtonsoft.Json (>= 10.0.1) - restriction: && (< net45) (>= netstandard2.0)
       Newtonsoft.Json.Bson (>= 1.0.1) - restriction: && (< net45) (>= netstandard2.0)
-    Microsoft.AspNetCore (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Diagnostics (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.HostFiltering (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
@@ -43,158 +43,158 @@ NUGET
       Microsoft.Extensions.Logging.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Console (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Debug (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Antiforgery (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Antiforgery (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.App (2.1.5)
-      Microsoft.AspNet.WebApi.Client (>= 5.2.6 < 5.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Antiforgery (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Facebook (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Google (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.JwtBearer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.MicrosoftAccount (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.OpenIdConnect (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Twitter (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.WsFederation (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authorization (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authorization.Policy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.CookiePolicy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Cors (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.DataProtection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.DataProtection.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Diagnostics (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.HostFiltering (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Connections (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Connections.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Features (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.HttpOverrides (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.HttpsPolicy (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Identity (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Identity.EntityFrameworkCore (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Identity.UI (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.JsonPatch (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Localization.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.MiddlewareAnalysis (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Analyzers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Formatters.Xml (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Localization (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.NodeServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Owin (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Razor.Design (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Razor.Language (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Razor.Runtime (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.ResponseCaching (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.ResponseCompression (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Rewrite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.HttpSys (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.IISIntegration (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.Kestrel (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Session (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SignalR (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SignalR.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SignalR.Core (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SpaServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SpaServices.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.StaticFiles (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.WebSockets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.WebUtilities (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.CodeAnalysis.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Design (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.InMemory (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Relational (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.SqlServer (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Tools (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Caching.Abstractions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Caching.Memory (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Caching.SqlServer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Binder (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.CommandLine (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Ini (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Json (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.KeyPerFile (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.UserSecrets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Xml (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.DependencyInjection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.DiagnosticAdapter (>= 2.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileProviders.Composite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Identity.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Identity.Stores (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Localization.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.Console (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.Debug (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.EventSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.TraceSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.ObjectPool (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Options (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Primitives (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.WebEncoders (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Net.Http.Headers (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      System.IO.Pipelines (>= 4.5.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNet.WebApi.Client (>= 5.2.6 < 5.3) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Antiforgery (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.Facebook (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.Google (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.JwtBearer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.MicrosoftAccount (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.OpenIdConnect (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.Twitter (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.WsFederation (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authorization (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authorization.Policy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.CookiePolicy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Cors (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.DataProtection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.DataProtection.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Diagnostics (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.HostFiltering (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Http.Connections (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Http.Connections.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Http.Features (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.HttpOverrides (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.HttpsPolicy (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Identity (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Identity.EntityFrameworkCore (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Identity.UI (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.JsonPatch (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Localization.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.MiddlewareAnalysis (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Analyzers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Formatters.Xml (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Localization (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.NodeServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Owin (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Razor.Design (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Razor.Language (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Razor.Runtime (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.ResponseCaching (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.ResponseCompression (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Rewrite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.HttpSys (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.IISIntegration (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.Kestrel (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Session (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.SignalR (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.SignalR.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.SignalR.Core (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.SpaServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.SpaServices.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.StaticFiles (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.WebSockets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.WebUtilities (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.CodeAnalysis.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.Design (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.InMemory (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.Relational (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.SqlServer (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.Tools (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Caching.Abstractions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Caching.Memory (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Caching.SqlServer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.Binder (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.CommandLine (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.Ini (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.Json (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.KeyPerFile (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.UserSecrets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.Xml (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.DependencyInjection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.DiagnosticAdapter (>= 2.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.FileProviders.Composite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Identity.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Identity.Stores (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Localization.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging.Console (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging.Debug (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging.EventSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging.TraceSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.ObjectPool (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Options (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Primitives (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.WebEncoders (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Net.Http.Headers (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      System.IO.Pipelines (>= 4.5.2) - restriction: >= netcoreapp3.1
     Microsoft.AspNetCore.Authentication (2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
@@ -203,60 +203,60 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.WebEncoders (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Cookies (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.Cookies (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Core (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.Core (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Facebook (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.Facebook (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Google (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.Google (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.JwtBearer (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.JwtBearer (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.OpenIdConnect (>= 5.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.MicrosoftAccount (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.MicrosoftAccount (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.OAuth (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.OAuth (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.OpenIdConnect (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.OpenIdConnect (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.OpenIdConnect (>= 5.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Twitter (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.Twitter (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.WsFederation (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.WsFederation (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.WsFederation (>= 5.2) - restriction: >= netstandard2.0
       System.IdentityModel.Tokens.Jwt (>= 5.2) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.Authorization (2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authorization.Policy (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authorization.Policy (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Authorization (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Connections.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Connections.Abstractions (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       System.IO.Pipelines (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.CookiePolicy (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.CookiePolicy (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cors (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Cors (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cryptography.Internal (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Cryptography.KeyDerivation (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Cryptography.Internal (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.AspNetCore.Cryptography.KeyDerivation (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.DataProtection (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.DataProtection (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -266,8 +266,8 @@ NUGET
       Microsoft.Win32.Registry (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Cryptography.Xml (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.DataProtection.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.DataProtection.Extensions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.DataProtection.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.AspNetCore.DataProtection.Extensions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.Diagnostics (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -280,11 +280,11 @@ NUGET
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
       System.Reflection.Metadata (>= 1.6) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Diagnostics.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Diagnostics.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HostFiltering (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.HostFiltering (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -307,10 +307,10 @@ NUGET
       Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Html.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Html.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.Http (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -318,10 +318,10 @@ NUGET
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Http.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Connections (1.0.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Http.Connections (1.0.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authorization.Policy (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
@@ -329,58 +329,58 @@ NUGET
       Microsoft.AspNetCore.Routing (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebSockets (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Connections.Common (1.0.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Http.Connections.Common (1.0.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Extensions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Http.Extensions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Features (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Http.Features (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HttpOverrides (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.HttpOverrides (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HttpsPolicy (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.HttpsPolicy (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Identity (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity.EntityFrameworkCore (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Identity.EntityFrameworkCore (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Identity (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Stores (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity.UI (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Identity.UI (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Identity (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.StaticFiles (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Stores (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.JsonPatch (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.JsonPatch (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.CSharp (>= 4.5) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Localization (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Localization (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Localization.Routing (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Localization.Routing (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.MiddlewareAnalysis (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.MiddlewareAnalysis (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3) - restriction: >= netstandard2.0
@@ -393,13 +393,13 @@ NUGET
       Microsoft.AspNetCore.Razor.Design (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Abstractions (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Analyzers (2.1.3) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Mvc.ApiExplorer (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Analyzers (2.1.3) - restriction: >= netcoreapp3.1
+    Microsoft.AspNetCore.Mvc.ApiExplorer (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Core (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Core (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Authorization.Policy (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -414,24 +414,24 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5.1) - restriction: >= netstandard2.0
       System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Cors (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Cors (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Cors (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.DataAnnotations (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.DataAnnotations (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Formatters.Json (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Formatters.Json (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.JsonPatch (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Formatters.Xml (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Formatters.Xml (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Localization (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Localization (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Razor (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Razor (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Razor.Runtime (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -439,22 +439,22 @@ NUGET
       Microsoft.CodeAnalysis.Razor (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.FileProviders.Composite (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNetCore.Mvc.Razor.Extensions (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Razor.Extensions (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Razor.Language (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.Razor (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
-    Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: || (>= net461) (>= netcoreapp2.0)
       Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.1) - restriction: || (>= net461) (>= netcoreapp2.0)
-    Microsoft.AspNetCore.Mvc.RazorPages (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.RazorPages (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.TagHelpers (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.TagHelpers (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Razor.Runtime (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.ViewFeatures (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.ViewFeatures (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Antiforgery (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -463,17 +463,17 @@ NUGET
       Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.WebEncoders (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json.Bson (>= 1.0.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.NodeServices (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.NodeServices (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Console (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Owin (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Owin (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Razor (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor.Design (2.1.2) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Razor.Language (2.1.2) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Razor.Runtime (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Razor.Design (2.1.2) - restriction: >= netcoreapp3.1
+    Microsoft.AspNetCore.Razor.Language (2.1.2) - restriction: >= netcoreapp3.1
+    Microsoft.AspNetCore.Razor.Runtime (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Razor (>= 2.1.2) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.ResponseCaching (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -482,33 +482,33 @@ NUGET
       Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCompression (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.ResponseCompression (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNetCore.Rewrite (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Rewrite (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Routing (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Routing (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Routing.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Routing.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.HttpSys (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.HttpSys (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Win32.Registry (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.IISIntegration (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.IISIntegration (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
@@ -522,12 +522,12 @@ NUGET
       System.Numerics.Vectors (>= 4.5) - restriction: >= netstandard2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5.2) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.Kestrel (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Core (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.Kestrel.Core (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
@@ -540,30 +540,30 @@ NUGET
       System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
       System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netstandard2.0
       System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Https (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.Kestrel.Https (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Session (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Session (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR (1.0.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.SignalR (1.0.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Connections (>= 1.0.4) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Core (>= 1.0.4) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Common (1.0.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.SignalR.Common (1.0.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Core (1.0.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.SignalR.Core (1.0.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authorization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Common (>= 1.0.4) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4) - restriction: >= netstandard2.0
@@ -571,19 +571,19 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Reflection.Emit (>= 4.3) - restriction: >= netstandard2.0
       System.Threading.Channels (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Protocols.Json (1.0.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.SignalR.Protocols.Json (1.0.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.SignalR.Common (>= 1.0.4) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SpaServices (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.SpaServices (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.NodeServices (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SpaServices.Extensions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.SpaServices.Extensions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.SpaServices (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.StaticFiles (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebSockets (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.StaticFiles (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.StaticFiles (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -592,15 +592,15 @@ NUGET
     Microsoft.AspNetCore.TestHost (2.1.1)
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       System.IO.Pipelines (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.WebSockets (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.WebSockets (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Net.WebSockets.WebSocketProtocol (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.WebUtilities (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.WebUtilities (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.CodeAnalysis.Analyzers (2.6.2) - restriction: >= netcoreapp3.0
-    Microsoft.CodeAnalysis.Common (2.9) - restriction: >= netcoreapp3.0
+    Microsoft.CodeAnalysis.Analyzers (2.6.2) - restriction: >= netcoreapp3.1
+    Microsoft.CodeAnalysis.Common (2.9) - restriction: >= netcoreapp3.1
       Microsoft.CodeAnalysis.Analyzers (>= 2.6.1) - restriction: >= netstandard1.3
       System.AppContext (>= 4.3) - restriction: >= netstandard1.3
       System.Collections (>= 4.3) - restriction: >= netstandard1.3
@@ -641,15 +641,15 @@ NUGET
       System.Xml.XDocument (>= 4.3) - restriction: >= netstandard1.3
       System.Xml.XmlDocument (>= 4.3) - restriction: >= netstandard1.3
       System.Xml.XPath.XDocument (>= 4.3) - restriction: >= netstandard1.3
-    Microsoft.CodeAnalysis.CSharp (2.9) - restriction: >= netcoreapp3.0
+    Microsoft.CodeAnalysis.CSharp (2.9) - restriction: >= netcoreapp3.1
       Microsoft.CodeAnalysis.Common (2.9)
-    Microsoft.CodeAnalysis.Razor (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.CodeAnalysis.Razor (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Razor.Language (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.Common (>= 2.8) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.CSharp (>= 2.8) - restriction: || (>= net46) (>= netstandard2.0)
     Microsoft.CodeCoverage (15.9) - restriction: || (>= net45) (>= netcoreapp1.0)
-    Microsoft.CSharp (4.5) - restriction: >= netcoreapp3.0
-    Microsoft.DotNet.PlatformAbstractions (2.1) - restriction: >= netcoreapp3.0
+    Microsoft.CSharp (4.5) - restriction: >= netcoreapp3.1
+    Microsoft.DotNet.PlatformAbstractions (2.1) - restriction: >= netcoreapp3.1
       System.AppContext (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Collections (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.3)
       System.IO (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
@@ -658,7 +658,7 @@ NUGET
       System.Runtime.Extensions (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Runtime.InteropServices (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Runtime.InteropServices.RuntimeInformation (>= 4.0) - restriction: || (>= net45) (>= netstandard1.3)
-    Microsoft.EntityFrameworkCore (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
@@ -669,171 +669,171 @@ NUGET
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5.1) - restriction: >= netstandard2.0
       System.Interactive.Async (>= 3.1.1) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Abstractions (2.1.4) - restriction: >= netcoreapp3.0
-    Microsoft.EntityFrameworkCore.Analyzers (2.1.4) - restriction: >= netcoreapp3.0
-    Microsoft.EntityFrameworkCore.Design (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.Abstractions (2.1.4) - restriction: >= netcoreapp3.1
+    Microsoft.EntityFrameworkCore.Analyzers (2.1.4) - restriction: >= netcoreapp3.1
+    Microsoft.EntityFrameworkCore.Design (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.CSharp (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.4) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.EntityFrameworkCore.InMemory (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.InMemory (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.EntityFrameworkCore (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Relational (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.Relational (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.EntityFrameworkCore (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.SqlServer (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.SqlServer (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.4) - restriction: >= netstandard2.0
       System.Data.SqlClient (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Tools (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.Tools (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.EntityFrameworkCore.Design (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.Abstractions (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Caching.Abstractions (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.Memory (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Caching.Memory (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.SqlServer (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Caching.SqlServer (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Data.SqlClient (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Binder (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.Binder (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.CommandLine (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.CommandLine (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.EnvironmentVariables (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.EnvironmentVariables (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.FileExtensions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.FileExtensions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Ini (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.Ini (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Json (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.Json (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.KeyPerFile (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.KeyPerFile (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.UserSecrets (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.UserSecrets (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration.Json (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Xml (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.Xml (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Security.Cryptography.Xml (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.DependencyInjection (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.DependencyInjection (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.DependencyInjection.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.DependencyInjection.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
     Microsoft.Extensions.DependencyModel (2.1) - restriction: >= netcoreapp1.0
       Microsoft.DotNet.PlatformAbstractions (>= 2.1) - restriction: || (>= net451) (>= netstandard1.3)
       Newtonsoft.Json (>= 9.0.1) - restriction: || (>= net451) (>= netstandard1.3)
       System.Diagnostics.Debug (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
       System.Dynamic.Runtime (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
       System.Linq (>= 4.1) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
-    Microsoft.Extensions.DiagnosticAdapter (2.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.DiagnosticAdapter (2.1) - restriction: >= netcoreapp3.1
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.FileProviders.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.FileProviders.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Composite (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.FileProviders.Composite (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Embedded (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.FileProviders.Embedded (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Physical (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.FileProviders.Physical (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileSystemGlobbing (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.Extensions.Hosting (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.FileSystemGlobbing (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.Extensions.Hosting (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Hosting.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Hosting.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Http (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Http (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Identity.Core (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Identity.Core (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Identity.Stores (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Identity.Stores (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Identity.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Localization (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Localization (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Localization.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.Extensions.Logging (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Localization.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.Extensions.Logging (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.Extensions.Logging.Configuration (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.Extensions.Logging.Configuration (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Console (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging.Console (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Debug (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging.Debug (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.EventSource (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging.EventSource (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.TraceSource (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging.TraceSource (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.ObjectPool (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.Extensions.Options (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.ObjectPool (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.Extensions.Options (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Options.ConfigurationExtensions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Options.ConfigurationExtensions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Primitives (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Primitives (2.1.1) - restriction: >= netcoreapp3.1
       System.Memory (>= 4.5.1) - restriction: >= netstandard2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.WebEncoders (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.WebEncoders (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.IdentityModel.JsonWebTokens (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.JsonWebTokens (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Logging (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Logging (5.3) - restriction: >= netcoreapp3.1
       System.Diagnostics.Tracing (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Globalization (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IO (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IO.FileSystem (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Protocols (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Protocols (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Logging (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Collections.Specialized (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Diagnostics.Contracts (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Net.Http (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Protocols.OpenIdConnect (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Protocols.OpenIdConnect (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Protocols (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Dynamic.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IdentityModel.Tokens.Jwt (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Protocols.WsFederation (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Protocols.WsFederation (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Protocols (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens.Saml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Xml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Xml.XmlDocument (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Tokens (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Tokens (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Logging (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Collections (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
@@ -849,12 +849,12 @@ NUGET
       System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Text.RegularExpressions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Threading (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Tokens.Saml (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Tokens.Saml (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Xml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Xml (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Xml (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.Net.Http.Headers (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Net.Http.Headers (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
     Microsoft.NET.Test.Sdk (15.9)
@@ -895,10 +895,10 @@ NUGET
     NETStandard.Library (2.0.3) - restriction: || (&& (< net35) (>= netstandard1.1) (< netstandard2.0)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= netstandard2.0)) (&& (< net452) (>= netstandard1.1)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (>= net45) (< netstandard1.3)) (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.4)) (>= net461) (>= netcoreapp2.0) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8) (< win8)) (&& (< netstandard1.0) (< portable-net45+win8) (>= portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard1.3) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= uap10.0)) (>= uap10.1) (>= wp8)
     Newtonsoft.Json (11.0.2) - restriction: || (>= net461) (>= netcoreapp1.0) (>= netstandard2.0) (>= uap10.0)
-    Newtonsoft.Json.Bson (1.0.1) - restriction: >= netcoreapp3.0
+    Newtonsoft.Json.Bson (1.0.1) - restriction: >= netcoreapp3.1
       NETStandard.Library (>= 1.6.1) - restriction: && (< net45) (>= netstandard1.3)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (>= net45) (>= netstandard1.3)
-    Remotion.Linq (2.2) - restriction: >= netcoreapp3.0
+    Remotion.Linq (2.2) - restriction: >= netcoreapp3.1
       System.Collections (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
       System.Diagnostics.Debug (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
       System.Linq (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
@@ -910,28 +910,28 @@ NUGET
       System.Runtime (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
       System.Runtime.Extensions (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
       System.Threading (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
-    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
     runtime.native.System (4.3.1) - restriction: >= netcoreapp1.0
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Data.SqlClient.sni (4.5) - restriction: >= netcoreapp3.0
+    runtime.native.System.Data.SqlClient.sni (4.5) - restriction: >= netcoreapp3.1
       runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (>= 4.4)
       runtime.win-x64.runtime.native.System.Data.SqlClient.sni (>= 4.4)
       runtime.win-x86.runtime.native.System.Data.SqlClient.sni (>= 4.4)
-    runtime.native.System.IO.Compression (4.3.2) - restriction: >= netcoreapp3.0
+    runtime.native.System.IO.Compression (4.3.2) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Net.Http (4.3.1) - restriction: >= netcoreapp3.0
+    runtime.native.System.Net.Http (4.3.1) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.0
+    runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.1
       runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (>= 4.3.1)
-    runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
       runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
@@ -947,22 +947,22 @@ NUGET
       runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.0
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
-    runtime.win-x64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
-    runtime.win-x86.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
-    System.AppContext (4.3) - restriction: >= netcoreapp3.0
+    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.1
+    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.1
+    runtime.win-x64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.1
+    runtime.win-x86.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.1
+    System.AppContext (4.3) - restriction: >= netcoreapp3.1
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Buffers (4.5) - restriction: >= netcoreapp3.0
+    System.Buffers (4.5) - restriction: >= netcoreapp3.1
     System.Collections (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -978,15 +978,15 @@ NUGET
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
-    System.Collections.Immutable (1.5) - restriction: >= netcoreapp3.0
-    System.Collections.NonGeneric (4.3) - restriction: >= netcoreapp3.0
+    System.Collections.Immutable (1.5) - restriction: >= netcoreapp3.1
+    System.Collections.NonGeneric (4.3) - restriction: >= netcoreapp3.1
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Collections.Specialized (4.3) - restriction: >= netcoreapp3.0
+    System.Collections.Specialized (4.3) - restriction: >= netcoreapp3.1
       System.Collections.NonGeneric (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -994,7 +994,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.ComponentModel.Annotations (4.5) - restriction: >= netcoreapp3.0
+    System.ComponentModel.Annotations (4.5) - restriction: >= netcoreapp3.1
     System.ComponentModel.EventBasedAsync (4.3) - restriction: >= netcoreapp1.0
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -1003,25 +1003,25 @@ NUGET
     System.ComponentModel.Primitives (4.3) - restriction: >= uap10.0
     System.ComponentModel.TypeConverter (4.3) - restriction: || (>= netcoreapp1.0) (>= uap10.0)
       System.ComponentModel.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.5) (< win8)) (&& (>= net45) (< netstandard1.5)) (>= net462) (&& (< netstandard1.0) (>= win8)) (>= wp8) (>= wpa81)
-    System.Console (4.3.1) - restriction: >= netcoreapp3.0
+    System.Console (4.3.1) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1.2) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Data.SqlClient (4.5.1) - restriction: >= netcoreapp3.0
+    System.Data.SqlClient (4.5.1) - restriction: >= netcoreapp3.1
       Microsoft.Win32.Registry (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       runtime.native.System.Data.SqlClient.sni (>= 4.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net451) (>= netstandard1.3) (< netstandard2.0) (< win81) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       System.Security.Principal.Windows (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       System.Text.Encoding.CodePages (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
-    System.Diagnostics.Contracts (4.3) - restriction: >= netcoreapp3.0
+    System.Diagnostics.Contracts (4.3) - restriction: >= netcoreapp3.1
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
     System.Diagnostics.Debug (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (>= netstandard1.6)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Diagnostics.DiagnosticSource (4.5.1) - restriction: >= netcoreapp3.0
-    System.Diagnostics.FileVersionInfo (4.3) - restriction: >= netcoreapp3.0
+    System.Diagnostics.DiagnosticSource (4.5.1) - restriction: >= netcoreapp3.1
+    System.Diagnostics.FileVersionInfo (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1053,7 +1053,7 @@ NUGET
       System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.Thread (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.ThreadPool (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.StackTrace (4.3) - restriction: >= netcoreapp3.0
+    System.Diagnostics.StackTrace (4.3) - restriction: >= netcoreapp3.1
       System.IO.FileSystem (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection.Metadata (>= 1.4.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1065,7 +1065,7 @@ NUGET
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.Tools (4.3) - restriction: >= netcoreapp3.0
+    System.Diagnostics.Tools (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1079,11 +1079,11 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.Tracing (4.3) - restriction: >= netcoreapp3.0
+    System.Diagnostics.Tracing (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Dynamic.Runtime (4.3) - restriction: >= netcoreapp3.0
+    System.Dynamic.Runtime (4.3) - restriction: >= netcoreapp3.1
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Linq (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1102,30 +1102,30 @@ NUGET
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Globalization.Calendars (4.3) - restriction: >= netcoreapp3.0
+    System.Globalization.Calendars (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Globalization.Extensions (4.3) - restriction: >= netcoreapp3.0
+    System.Globalization.Extensions (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.IdentityModel.Tokens.Jwt (5.3) - restriction: >= netcoreapp3.0
+    System.IdentityModel.Tokens.Jwt (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.JsonWebTokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    System.Interactive.Async (3.2) - restriction: >= netcoreapp3.0
+    System.Interactive.Async (3.2) - restriction: >= netcoreapp3.1
     System.IO (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.IO.Compression (4.3) - restriction: >= netcoreapp3.0
+    System.IO.Compression (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.IO.Compression (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1159,7 +1159,7 @@ NUGET
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.6) (< win8) (< wp8) (< wpa81))
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Linq.Expressions (4.3) - restriction: >= netcoreapp3.0
+    System.Linq.Expressions (4.3) - restriction: >= netcoreapp3.1
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1177,7 +1177,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Linq.Queryable (4.3) - restriction: >= netcoreapp3.0
+    System.Linq.Queryable (4.3) - restriction: >= netcoreapp3.1
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Linq (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -1186,8 +1186,8 @@ NUGET
       System.Reflection.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Memory (4.5.1) - restriction: >= netcoreapp3.0
-    System.Net.Http (4.3.4) - restriction: >= netcoreapp3.0
+    System.Memory (4.5.1) - restriction: >= netcoreapp3.1
+    System.Net.Http (4.3.4) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Net.Http (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1214,14 +1214,14 @@ NUGET
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-    System.Net.Primitives (4.3) - restriction: >= netcoreapp3.0
+    System.Net.Primitives (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       System.Runtime.Handles (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Net.WebSockets.WebSocketProtocol (4.5.2) - restriction: >= netcoreapp3.0
-    System.Numerics.Vectors (4.5) - restriction: >= netcoreapp3.0
-    System.ObjectModel (4.3) - restriction: >= netcoreapp3.0
+    System.Net.WebSockets.WebSocketProtocol (4.5.2) - restriction: >= netcoreapp3.1
+    System.Numerics.Vectors (4.5) - restriction: >= netcoreapp3.1
+    System.ObjectModel (4.3) - restriction: >= netcoreapp3.1
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1259,7 +1259,7 @@ NUGET
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Reflection.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Reflection.Emit (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.0)
+    System.Reflection.Emit (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.1)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1294,7 +1294,7 @@ NUGET
     System.Runtime (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= net461) (< netstandard1.6)) (&& (< net45) (>= net461) (< netstandard2.0)) (&& (< net45) (>= net47)) (&& (>= net461) (>= netcoreapp1.1)) (>= netcoreapp1.0) (&& (>= netcoreapp1.1) (>= netstandard2.0))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Runtime.CompilerServices.Unsafe (4.5.2) - restriction: >= netcoreapp3.0
+    System.Runtime.CompilerServices.Unsafe (4.5.2) - restriction: >= netcoreapp3.1
     System.Runtime.Extensions (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
@@ -1315,7 +1315,7 @@ NUGET
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Runtime.Numerics (4.3) - restriction: >= netcoreapp3.0
+    System.Runtime.Numerics (4.3) - restriction: >= netcoreapp3.1
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
@@ -1327,17 +1327,17 @@ NUGET
     System.Runtime.Serialization.Primitives (4.3) - restriction: >= netcoreapp1.0
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Runtime.Serialization.Xml (4.3) - restriction: >= netcoreapp3.0
+    System.Runtime.Serialization.Xml (4.3) - restriction: >= netcoreapp3.1
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Private.DataContractSerialization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime.Serialization.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Xml.ReaderWriter (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Security.AccessControl (4.5) - restriction: >= netcoreapp3.0
+    System.Security.AccessControl (4.5) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: || (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0)
-    System.Security.Claims (4.3) - restriction: >= netcoreapp3.0
+    System.Security.Claims (4.3) - restriction: >= netcoreapp3.1
       System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1345,7 +1345,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Security.Principal (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.Algorithms (4.3.1) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Algorithms (4.3.1) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       runtime.native.System.Security.Cryptography.Apple (>= 4.3.1) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.2) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1360,8 +1360,8 @@ NUGET
       System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net463)
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net46) (< netstandard1.4)) (&& (>= net461) (< netstandard1.6)) (>= net463)
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Cryptography.Cng (4.5) - restriction: >= netcoreapp3.0
-    System.Security.Cryptography.Csp (4.3) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Cng (4.5) - restriction: >= netcoreapp3.1
+    System.Security.Cryptography.Csp (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1375,7 +1375,7 @@ NUGET
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.Encoding (4.3) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Encoding (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1388,10 +1388,10 @@ NUGET
       System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.OpenSsl (4.5) - restriction: >= netcoreapp3.0
-    System.Security.Cryptography.Pkcs (4.5.1) - restriction: >= netcoreapp3.0
-      System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netcoreapp3.0
-    System.Security.Cryptography.Primitives (4.3) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.OpenSsl (4.5) - restriction: >= netcoreapp3.1
+    System.Security.Cryptography.Pkcs (4.5.1) - restriction: >= netcoreapp3.1
+      System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netcoreapp3.1
+    System.Security.Cryptography.Primitives (4.3) - restriction: >= netcoreapp3.1
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1399,7 +1399,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.X509Certificates (4.3.2) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.X509Certificates (4.3.2) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       runtime.native.System (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Net.Http (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1425,20 +1425,20 @@ NUGET
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Cryptography.Xml (4.5) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Xml (4.5) - restriction: >= netcoreapp3.1
       System.Security.Cryptography.Pkcs (>= 4.5) - restriction: && (< net461) (>= netstandard2.0)
       System.Security.Permissions (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Security.Permissions (4.5) - restriction: >= netcoreapp3.0
+    System.Security.Permissions (4.5) - restriction: >= netcoreapp3.1
       System.Security.AccessControl (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Security.Principal (4.3) - restriction: >= netcoreapp3.0
+    System.Security.Principal (4.3) - restriction: >= netcoreapp3.1
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Principal.Windows (4.5.1) - restriction: >= netcoreapp3.0
+    System.Security.Principal.Windows (4.5.1) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
     System.Text.Encoding (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5)) (&& (< net45) (>= net461) (< netstandard1.5)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Text.Encoding.CodePages (4.5) - restriction: >= netcoreapp3.0
+    System.Text.Encoding.CodePages (4.5) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: || (&& (< net46) (>= netstandard2.0) (< xamarinios)) (>= net461) (>= netcoreapp2.0)
     System.Text.Encoding.Extensions (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
@@ -1446,7 +1446,7 @@ NUGET
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Text.Encodings.Web (4.5) - restriction: >= netcoreapp3.0
+    System.Text.Encodings.Web (4.5) - restriction: >= netcoreapp3.1
     System.Text.RegularExpressions (4.3) - restriction: || (>= net461) (>= netcoreapp1.0) (>= netstandard2.0)
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1457,13 +1457,13 @@ NUGET
     System.Threading (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Threading.Channels (4.5) - restriction: >= netcoreapp3.0
+    System.Threading.Channels (4.5) - restriction: >= netcoreapp3.1
     System.Threading.Tasks (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5)) (&& (< net45) (>= net461) (< netstandard1.5)) (&& (< net45) (>= net461) (>= netstandard1.6)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Threading.Tasks.Extensions (4.5.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.0)
-    System.Threading.Tasks.Parallel (4.3) - restriction: >= netcoreapp3.0
+    System.Threading.Tasks.Extensions (4.5.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.1)
+    System.Threading.Tasks.Parallel (4.3) - restriction: >= netcoreapp3.1
       System.Collections.Concurrent (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Tracing (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1477,7 +1477,7 @@ NUGET
     System.Threading.ThreadPool (4.3) - restriction: >= netcoreapp1.0
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Handles (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.ValueTuple (4.5) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.6) (>= netstandard2.0)) (>= net461) (>= netcoreapp3.0)
+    System.ValueTuple (4.5) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.6) (>= netstandard2.0)) (>= net461) (>= netcoreapp3.1)
     System.Xml.ReaderWriter (4.3.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1546,7 +1546,7 @@ NUGET
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Xml.ReaderWriter (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Xml.XPath.XDocument (4.3) - restriction: >= netcoreapp3.0
+    System.Xml.XPath.XDocument (4.3) - restriction: >= netcoreapp3.1
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Linq (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)

--- a/src/content/DotLiquid/paket.lock
+++ b/src/content/DotLiquid/paket.lock
@@ -23,10 +23,10 @@ NUGET
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       System.ValueTuple (>= 4.4) - restriction: >= net461
-    Microsoft.AspNet.WebApi.Client (5.2.6) - restriction: >= netcoreapp2.1
+    Microsoft.AspNet.WebApi.Client (5.2.6) - restriction: >= netcoreapp3.0
       Newtonsoft.Json (>= 10.0.1) - restriction: && (< net45) (>= netstandard2.0)
       Newtonsoft.Json.Bson (>= 1.0.1) - restriction: && (< net45) (>= netstandard2.0)
-    Microsoft.AspNetCore (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Diagnostics (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.HostFiltering (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
@@ -43,158 +43,158 @@ NUGET
       Microsoft.Extensions.Logging.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Console (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Debug (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Antiforgery (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Antiforgery (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.App (2.1.5)
-      Microsoft.AspNet.WebApi.Client (>= 5.2.6 < 5.3) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Antiforgery (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Facebook (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Google (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.JwtBearer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.MicrosoftAccount (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.OpenIdConnect (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Twitter (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.WsFederation (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authorization (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authorization.Policy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.CookiePolicy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Cors (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.DataProtection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.DataProtection.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Diagnostics (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.HostFiltering (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http.Connections (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http.Connections.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http.Features (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.HttpOverrides (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.HttpsPolicy (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Identity (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Identity.EntityFrameworkCore (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Identity.UI (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.JsonPatch (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Localization.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.MiddlewareAnalysis (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Analyzers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Formatters.Xml (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Localization (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.NodeServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Owin (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Razor.Design (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Razor.Language (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Razor.Runtime (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.ResponseCaching (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.ResponseCompression (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Rewrite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.HttpSys (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.IISIntegration (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.Kestrel (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Session (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SignalR (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SignalR.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SignalR.Core (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SpaServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SpaServices.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.StaticFiles (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.WebSockets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.WebUtilities (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.CodeAnalysis.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.Design (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.InMemory (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.Relational (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.SqlServer (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.Tools (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Caching.Abstractions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Caching.Memory (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Caching.SqlServer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.Binder (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.CommandLine (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.Ini (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.Json (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.KeyPerFile (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.UserSecrets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.Xml (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.DependencyInjection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.DiagnosticAdapter (>= 2.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.FileProviders.Composite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Identity.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Identity.Stores (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Localization.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.Console (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.Debug (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.EventSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.TraceSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.ObjectPool (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Options (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Primitives (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.WebEncoders (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Net.Http.Headers (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      System.IO.Pipelines (>= 4.5.2) - restriction: >= netcoreapp2.1
+      Microsoft.AspNet.WebApi.Client (>= 5.2.6 < 5.3) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Antiforgery (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Facebook (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Google (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.JwtBearer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.MicrosoftAccount (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.OpenIdConnect (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Twitter (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.WsFederation (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authorization (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authorization.Policy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.CookiePolicy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Cors (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.DataProtection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.DataProtection.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Diagnostics (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.HostFiltering (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http.Connections (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http.Connections.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http.Features (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.HttpOverrides (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.HttpsPolicy (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Identity (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Identity.EntityFrameworkCore (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Identity.UI (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.JsonPatch (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Localization.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.MiddlewareAnalysis (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Analyzers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Formatters.Xml (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Localization (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.NodeServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Owin (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Razor.Design (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Razor.Language (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Razor.Runtime (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.ResponseCaching (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.ResponseCompression (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Rewrite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.HttpSys (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.IISIntegration (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.Kestrel (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Session (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SignalR (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SignalR.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SignalR.Core (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SpaServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SpaServices.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.StaticFiles (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.WebSockets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.WebUtilities (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.CodeAnalysis.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.Design (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.InMemory (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.Relational (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.SqlServer (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.Tools (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Caching.Abstractions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Caching.Memory (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Caching.SqlServer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.Binder (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.CommandLine (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.Ini (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.Json (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.KeyPerFile (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.UserSecrets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.Xml (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.DependencyInjection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.DiagnosticAdapter (>= 2.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.FileProviders.Composite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Identity.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Identity.Stores (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Localization.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.Console (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.Debug (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.EventSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.TraceSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.ObjectPool (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Options (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Primitives (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.WebEncoders (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Net.Http.Headers (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      System.IO.Pipelines (>= 4.5.2) - restriction: >= netcoreapp3.0
     Microsoft.AspNetCore.Authentication (2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
@@ -203,60 +203,60 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.WebEncoders (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Cookies (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Cookies (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Core (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Core (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Facebook (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Facebook (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Google (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Google (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.JwtBearer (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.JwtBearer (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.OpenIdConnect (>= 5.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.MicrosoftAccount (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.MicrosoftAccount (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.OAuth (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.OAuth (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.OpenIdConnect (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.OpenIdConnect (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.OpenIdConnect (>= 5.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Twitter (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Twitter (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.WsFederation (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.WsFederation (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.WsFederation (>= 5.2) - restriction: >= netstandard2.0
       System.IdentityModel.Tokens.Jwt (>= 5.2) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.Authorization (2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authorization.Policy (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authorization.Policy (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Authorization (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Connections.Abstractions (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Connections.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       System.IO.Pipelines (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.CookiePolicy (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.CookiePolicy (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cors (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Cors (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cryptography.Internal (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.Cryptography.KeyDerivation (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Cryptography.Internal (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Cryptography.KeyDerivation (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.DataProtection (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.DataProtection (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -266,8 +266,8 @@ NUGET
       Microsoft.Win32.Registry (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Cryptography.Xml (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.DataProtection.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.DataProtection.Extensions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.DataProtection.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.DataProtection.Extensions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.Diagnostics (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -280,11 +280,11 @@ NUGET
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
       System.Reflection.Metadata (>= 1.6) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Diagnostics.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Diagnostics.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HostFiltering (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.HostFiltering (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -307,10 +307,10 @@ NUGET
       Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Html.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Html.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.Http (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -318,10 +318,10 @@ NUGET
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Connections (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http.Connections (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authorization.Policy (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
@@ -329,58 +329,58 @@ NUGET
       Microsoft.AspNetCore.Routing (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebSockets (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Connections.Common (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http.Connections.Common (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Extensions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http.Extensions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Features (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http.Features (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HttpOverrides (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.HttpOverrides (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HttpsPolicy (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.HttpsPolicy (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Identity (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity.EntityFrameworkCore (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Identity.EntityFrameworkCore (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Identity (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Stores (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity.UI (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Identity.UI (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Identity (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.StaticFiles (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Stores (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.JsonPatch (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.JsonPatch (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.CSharp (>= 4.5) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Localization (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Localization (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Localization.Routing (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Localization.Routing (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.MiddlewareAnalysis (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.MiddlewareAnalysis (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3) - restriction: >= netstandard2.0
@@ -393,13 +393,13 @@ NUGET
       Microsoft.AspNetCore.Razor.Design (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Abstractions (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Analyzers (2.1.3) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.Mvc.ApiExplorer (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Analyzers (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.ApiExplorer (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Core (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Core (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Authorization.Policy (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -414,24 +414,24 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5.1) - restriction: >= netstandard2.0
       System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Cors (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Cors (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Cors (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.DataAnnotations (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.DataAnnotations (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Formatters.Json (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Formatters.Json (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.JsonPatch (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Formatters.Xml (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Formatters.Xml (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Localization (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Localization (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Razor (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Razor (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Razor.Runtime (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -439,22 +439,22 @@ NUGET
       Microsoft.CodeAnalysis.Razor (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.FileProviders.Composite (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNetCore.Mvc.Razor.Extensions (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Razor.Extensions (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Razor.Language (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.Razor (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
-    Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: || (>= net461) (>= netcoreapp2.0)
       Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.1) - restriction: || (>= net461) (>= netcoreapp2.0)
-    Microsoft.AspNetCore.Mvc.RazorPages (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.RazorPages (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.TagHelpers (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.TagHelpers (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Razor.Runtime (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.ViewFeatures (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.ViewFeatures (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Antiforgery (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -463,17 +463,17 @@ NUGET
       Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.WebEncoders (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json.Bson (>= 1.0.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.NodeServices (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.NodeServices (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Console (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Owin (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Owin (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Razor (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor.Design (2.1.2) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.Razor.Language (2.1.2) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.Razor.Runtime (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Razor.Design (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Razor.Language (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Razor.Runtime (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Razor (>= 2.1.2) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.ResponseCaching (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -482,33 +482,33 @@ NUGET
       Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCompression (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.ResponseCompression (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNetCore.Rewrite (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Rewrite (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Routing (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Routing (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Routing.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Routing.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.HttpSys (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.HttpSys (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Win32.Registry (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.IISIntegration (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.IISIntegration (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
@@ -522,12 +522,12 @@ NUGET
       System.Numerics.Vectors (>= 4.5) - restriction: >= netstandard2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5.2) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.Kestrel (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Core (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.Kestrel.Core (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
@@ -540,30 +540,30 @@ NUGET
       System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
       System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netstandard2.0
       System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Https (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.Kestrel.Https (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Session (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Session (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SignalR (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Connections (>= 1.0.4) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Core (>= 1.0.4) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Common (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SignalR.Common (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Core (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SignalR.Core (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authorization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Common (>= 1.0.4) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4) - restriction: >= netstandard2.0
@@ -571,19 +571,19 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Reflection.Emit (>= 4.3) - restriction: >= netstandard2.0
       System.Threading.Channels (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Protocols.Json (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SignalR.Protocols.Json (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.SignalR.Common (>= 1.0.4) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SpaServices (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SpaServices (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.NodeServices (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SpaServices.Extensions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SpaServices.Extensions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.SpaServices (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.StaticFiles (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebSockets (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.StaticFiles (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.StaticFiles (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -592,15 +592,15 @@ NUGET
     Microsoft.AspNetCore.TestHost (2.1.1)
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       System.IO.Pipelines (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.WebSockets (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.WebSockets (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Net.WebSockets.WebSocketProtocol (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.WebUtilities (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.WebUtilities (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.CodeAnalysis.Analyzers (2.6.2) - restriction: >= netcoreapp2.1
-    Microsoft.CodeAnalysis.Common (2.9) - restriction: >= netcoreapp2.1
+    Microsoft.CodeAnalysis.Analyzers (2.6.2) - restriction: >= netcoreapp3.0
+    Microsoft.CodeAnalysis.Common (2.9) - restriction: >= netcoreapp3.0
       Microsoft.CodeAnalysis.Analyzers (>= 2.6.1) - restriction: >= netstandard1.3
       System.AppContext (>= 4.3) - restriction: >= netstandard1.3
       System.Collections (>= 4.3) - restriction: >= netstandard1.3
@@ -641,15 +641,15 @@ NUGET
       System.Xml.XDocument (>= 4.3) - restriction: >= netstandard1.3
       System.Xml.XmlDocument (>= 4.3) - restriction: >= netstandard1.3
       System.Xml.XPath.XDocument (>= 4.3) - restriction: >= netstandard1.3
-    Microsoft.CodeAnalysis.CSharp (2.9) - restriction: >= netcoreapp2.1
+    Microsoft.CodeAnalysis.CSharp (2.9) - restriction: >= netcoreapp3.0
       Microsoft.CodeAnalysis.Common (2.9)
-    Microsoft.CodeAnalysis.Razor (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.CodeAnalysis.Razor (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Razor.Language (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.Common (>= 2.8) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.CSharp (>= 2.8) - restriction: || (>= net46) (>= netstandard2.0)
     Microsoft.CodeCoverage (15.9) - restriction: || (>= net45) (>= netcoreapp1.0)
-    Microsoft.CSharp (4.5) - restriction: >= netcoreapp2.1
-    Microsoft.DotNet.PlatformAbstractions (2.1) - restriction: >= netcoreapp2.1
+    Microsoft.CSharp (4.5) - restriction: >= netcoreapp3.0
+    Microsoft.DotNet.PlatformAbstractions (2.1) - restriction: >= netcoreapp3.0
       System.AppContext (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Collections (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.3)
       System.IO (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
@@ -658,7 +658,7 @@ NUGET
       System.Runtime.Extensions (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Runtime.InteropServices (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Runtime.InteropServices.RuntimeInformation (>= 4.0) - restriction: || (>= net45) (>= netstandard1.3)
-    Microsoft.EntityFrameworkCore (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
@@ -669,171 +669,171 @@ NUGET
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5.1) - restriction: >= netstandard2.0
       System.Interactive.Async (>= 3.1.1) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Abstractions (2.1.4) - restriction: >= netcoreapp2.1
-    Microsoft.EntityFrameworkCore.Analyzers (2.1.4) - restriction: >= netcoreapp2.1
-    Microsoft.EntityFrameworkCore.Design (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore.Abstractions (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.Analyzers (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.Design (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.CSharp (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.4) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.EntityFrameworkCore.InMemory (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore.InMemory (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.EntityFrameworkCore (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Relational (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore.Relational (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.EntityFrameworkCore (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.SqlServer (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore.SqlServer (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.4) - restriction: >= netstandard2.0
       System.Data.SqlClient (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Tools (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore.Tools (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.EntityFrameworkCore.Design (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.Abstractions (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Caching.Abstractions (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.Memory (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Caching.Memory (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.SqlServer (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Caching.SqlServer (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Data.SqlClient (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Binder (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.Binder (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.CommandLine (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.CommandLine (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.EnvironmentVariables (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.EnvironmentVariables (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.FileExtensions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.FileExtensions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Ini (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.Ini (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Json (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.Json (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.KeyPerFile (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.KeyPerFile (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.UserSecrets (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.UserSecrets (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Json (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Xml (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.Xml (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Security.Cryptography.Xml (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.DependencyInjection (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.DependencyInjection (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.DependencyInjection.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.DependencyInjection.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
     Microsoft.Extensions.DependencyModel (2.1) - restriction: >= netcoreapp1.0
       Microsoft.DotNet.PlatformAbstractions (>= 2.1) - restriction: || (>= net451) (>= netstandard1.3)
       Newtonsoft.Json (>= 9.0.1) - restriction: || (>= net451) (>= netstandard1.3)
       System.Diagnostics.Debug (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
       System.Dynamic.Runtime (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
       System.Linq (>= 4.1) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
-    Microsoft.Extensions.DiagnosticAdapter (2.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.DiagnosticAdapter (2.1) - restriction: >= netcoreapp3.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.FileProviders.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.FileProviders.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Composite (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.FileProviders.Composite (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Embedded (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.FileProviders.Embedded (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Physical (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.FileProviders.Physical (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileSystemGlobbing (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.Extensions.Hosting (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.FileSystemGlobbing (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Hosting (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Hosting.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Hosting.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Http (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Http (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Identity.Core (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Identity.Core (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Identity.Stores (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Identity.Stores (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Identity.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Localization (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Localization (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Localization.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.Extensions.Logging (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Localization.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.Extensions.Logging.Configuration (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Logging.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging.Configuration (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Console (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Logging.Console (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Debug (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Logging.Debug (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.EventSource (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Logging.EventSource (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.TraceSource (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Logging.TraceSource (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.ObjectPool (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.Extensions.Options (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.ObjectPool (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Options (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Options.ConfigurationExtensions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Options.ConfigurationExtensions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Primitives (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Primitives (2.1.1) - restriction: >= netcoreapp3.0
       System.Memory (>= 4.5.1) - restriction: >= netstandard2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.WebEncoders (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.WebEncoders (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.IdentityModel.JsonWebTokens (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.JsonWebTokens (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Logging (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Logging (5.3) - restriction: >= netcoreapp3.0
       System.Diagnostics.Tracing (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Globalization (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IO (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IO.FileSystem (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Protocols (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Protocols (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Logging (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Collections.Specialized (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Diagnostics.Contracts (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Net.Http (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Protocols.OpenIdConnect (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Protocols.OpenIdConnect (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Protocols (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Dynamic.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IdentityModel.Tokens.Jwt (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Protocols.WsFederation (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Protocols.WsFederation (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Protocols (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens.Saml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Xml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Xml.XmlDocument (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Tokens (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Tokens (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Logging (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Collections (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
@@ -849,12 +849,12 @@ NUGET
       System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Text.RegularExpressions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Threading (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Tokens.Saml (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Tokens.Saml (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Xml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Xml (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Xml (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.Net.Http.Headers (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Net.Http.Headers (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
     Microsoft.NET.Test.Sdk (15.9)
@@ -895,10 +895,10 @@ NUGET
     NETStandard.Library (2.0.3) - restriction: || (&& (< net35) (>= netstandard1.1) (< netstandard2.0)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= netstandard2.0)) (&& (< net452) (>= netstandard1.1)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (>= net45) (< netstandard1.3)) (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.4)) (>= net461) (>= netcoreapp2.0) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8) (< win8)) (&& (< netstandard1.0) (< portable-net45+win8) (>= portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard1.3) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= uap10.0)) (>= uap10.1) (>= wp8)
     Newtonsoft.Json (11.0.2) - restriction: || (>= net461) (>= netcoreapp1.0) (>= netstandard2.0) (>= uap10.0)
-    Newtonsoft.Json.Bson (1.0.1) - restriction: >= netcoreapp2.1
+    Newtonsoft.Json.Bson (1.0.1) - restriction: >= netcoreapp3.0
       NETStandard.Library (>= 1.6.1) - restriction: && (< net45) (>= netstandard1.3)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (>= net45) (>= netstandard1.3)
-    Remotion.Linq (2.2) - restriction: >= netcoreapp2.1
+    Remotion.Linq (2.2) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
       System.Diagnostics.Debug (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
       System.Linq (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
@@ -910,28 +910,28 @@ NUGET
       System.Runtime (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
       System.Runtime.Extensions (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
       System.Threading (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
-    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
+    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
     runtime.native.System (4.3.1) - restriction: >= netcoreapp1.0
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Data.SqlClient.sni (4.5) - restriction: >= netcoreapp2.1
+    runtime.native.System.Data.SqlClient.sni (4.5) - restriction: >= netcoreapp3.0
       runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (>= 4.4)
       runtime.win-x64.runtime.native.System.Data.SqlClient.sni (>= 4.4)
       runtime.win-x86.runtime.native.System.Data.SqlClient.sni (>= 4.4)
-    runtime.native.System.IO.Compression (4.3.2) - restriction: >= netcoreapp2.1
+    runtime.native.System.IO.Compression (4.3.2) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Net.Http (4.3.1) - restriction: >= netcoreapp2.1
+    runtime.native.System.Net.Http (4.3.1) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp2.1
+    runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.0
       runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (>= 4.3.1)
-    runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
+    runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
       runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
@@ -947,22 +947,22 @@ NUGET
       runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp2.1
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp2.1
-    runtime.win-x64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp2.1
-    runtime.win-x86.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp2.1
-    System.AppContext (4.3) - restriction: >= netcoreapp2.1
+    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.0
+    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
+    runtime.win-x64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
+    runtime.win-x86.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
+    System.AppContext (4.3) - restriction: >= netcoreapp3.0
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Buffers (4.5) - restriction: >= netcoreapp2.1
+    System.Buffers (4.5) - restriction: >= netcoreapp3.0
     System.Collections (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -978,15 +978,15 @@ NUGET
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
-    System.Collections.Immutable (1.5) - restriction: >= netcoreapp2.1
-    System.Collections.NonGeneric (4.3) - restriction: >= netcoreapp2.1
+    System.Collections.Immutable (1.5) - restriction: >= netcoreapp3.0
+    System.Collections.NonGeneric (4.3) - restriction: >= netcoreapp3.0
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Collections.Specialized (4.3) - restriction: >= netcoreapp2.1
+    System.Collections.Specialized (4.3) - restriction: >= netcoreapp3.0
       System.Collections.NonGeneric (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -994,7 +994,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.ComponentModel.Annotations (4.5) - restriction: >= netcoreapp2.1
+    System.ComponentModel.Annotations (4.5) - restriction: >= netcoreapp3.0
     System.ComponentModel.EventBasedAsync (4.3) - restriction: >= netcoreapp1.0
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -1003,25 +1003,25 @@ NUGET
     System.ComponentModel.Primitives (4.3) - restriction: >= uap10.0
     System.ComponentModel.TypeConverter (4.3) - restriction: || (>= netcoreapp1.0) (>= uap10.0)
       System.ComponentModel.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.5) (< win8)) (&& (>= net45) (< netstandard1.5)) (>= net462) (&& (< netstandard1.0) (>= win8)) (>= wp8) (>= wpa81)
-    System.Console (4.3.1) - restriction: >= netcoreapp2.1
+    System.Console (4.3.1) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1.2) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Data.SqlClient (4.5.1) - restriction: >= netcoreapp2.1
+    System.Data.SqlClient (4.5.1) - restriction: >= netcoreapp3.0
       Microsoft.Win32.Registry (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       runtime.native.System.Data.SqlClient.sni (>= 4.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net451) (>= netstandard1.3) (< netstandard2.0) (< win81) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       System.Security.Principal.Windows (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       System.Text.Encoding.CodePages (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
-    System.Diagnostics.Contracts (4.3) - restriction: >= netcoreapp2.1
+    System.Diagnostics.Contracts (4.3) - restriction: >= netcoreapp3.0
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
     System.Diagnostics.Debug (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (>= netstandard1.6)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Diagnostics.DiagnosticSource (4.5.1) - restriction: >= netcoreapp2.1
-    System.Diagnostics.FileVersionInfo (4.3) - restriction: >= netcoreapp2.1
+    System.Diagnostics.DiagnosticSource (4.5.1) - restriction: >= netcoreapp3.0
+    System.Diagnostics.FileVersionInfo (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1053,7 +1053,7 @@ NUGET
       System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.Thread (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.ThreadPool (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.StackTrace (4.3) - restriction: >= netcoreapp2.1
+    System.Diagnostics.StackTrace (4.3) - restriction: >= netcoreapp3.0
       System.IO.FileSystem (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection.Metadata (>= 1.4.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1065,7 +1065,7 @@ NUGET
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.Tools (4.3) - restriction: >= netcoreapp2.1
+    System.Diagnostics.Tools (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1079,11 +1079,11 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.Tracing (4.3) - restriction: >= netcoreapp2.1
+    System.Diagnostics.Tracing (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Dynamic.Runtime (4.3) - restriction: >= netcoreapp2.1
+    System.Dynamic.Runtime (4.3) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Linq (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1102,30 +1102,30 @@ NUGET
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Globalization.Calendars (4.3) - restriction: >= netcoreapp2.1
+    System.Globalization.Calendars (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Globalization.Extensions (4.3) - restriction: >= netcoreapp2.1
+    System.Globalization.Extensions (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.IdentityModel.Tokens.Jwt (5.3) - restriction: >= netcoreapp2.1
+    System.IdentityModel.Tokens.Jwt (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.JsonWebTokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    System.Interactive.Async (3.2) - restriction: >= netcoreapp2.1
+    System.Interactive.Async (3.2) - restriction: >= netcoreapp3.0
     System.IO (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.IO.Compression (4.3) - restriction: >= netcoreapp2.1
+    System.IO.Compression (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.IO.Compression (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1159,7 +1159,7 @@ NUGET
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.6) (< win8) (< wp8) (< wpa81))
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Linq.Expressions (4.3) - restriction: >= netcoreapp2.1
+    System.Linq.Expressions (4.3) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1177,7 +1177,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Linq.Queryable (4.3) - restriction: >= netcoreapp2.1
+    System.Linq.Queryable (4.3) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Linq (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -1186,8 +1186,8 @@ NUGET
       System.Reflection.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Memory (4.5.1) - restriction: >= netcoreapp2.1
-    System.Net.Http (4.3.4) - restriction: >= netcoreapp2.1
+    System.Memory (4.5.1) - restriction: >= netcoreapp3.0
+    System.Net.Http (4.3.4) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Net.Http (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1214,14 +1214,14 @@ NUGET
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-    System.Net.Primitives (4.3) - restriction: >= netcoreapp2.1
+    System.Net.Primitives (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       System.Runtime.Handles (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Net.WebSockets.WebSocketProtocol (4.5.2) - restriction: >= netcoreapp2.1
-    System.Numerics.Vectors (4.5) - restriction: >= netcoreapp2.1
-    System.ObjectModel (4.3) - restriction: >= netcoreapp2.1
+    System.Net.WebSockets.WebSocketProtocol (4.5.2) - restriction: >= netcoreapp3.0
+    System.Numerics.Vectors (4.5) - restriction: >= netcoreapp3.0
+    System.ObjectModel (4.3) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1259,7 +1259,7 @@ NUGET
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Reflection.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Reflection.Emit (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp2.1)
+    System.Reflection.Emit (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.0)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1294,7 +1294,7 @@ NUGET
     System.Runtime (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= net461) (< netstandard1.6)) (&& (< net45) (>= net461) (< netstandard2.0)) (&& (< net45) (>= net47)) (&& (>= net461) (>= netcoreapp1.1)) (>= netcoreapp1.0) (&& (>= netcoreapp1.1) (>= netstandard2.0))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Runtime.CompilerServices.Unsafe (4.5.2) - restriction: >= netcoreapp2.1
+    System.Runtime.CompilerServices.Unsafe (4.5.2) - restriction: >= netcoreapp3.0
     System.Runtime.Extensions (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
@@ -1315,7 +1315,7 @@ NUGET
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Runtime.Numerics (4.3) - restriction: >= netcoreapp2.1
+    System.Runtime.Numerics (4.3) - restriction: >= netcoreapp3.0
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
@@ -1327,17 +1327,17 @@ NUGET
     System.Runtime.Serialization.Primitives (4.3) - restriction: >= netcoreapp1.0
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Runtime.Serialization.Xml (4.3) - restriction: >= netcoreapp2.1
+    System.Runtime.Serialization.Xml (4.3) - restriction: >= netcoreapp3.0
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Private.DataContractSerialization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime.Serialization.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Xml.ReaderWriter (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Security.AccessControl (4.5) - restriction: >= netcoreapp2.1
+    System.Security.AccessControl (4.5) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: || (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0)
-    System.Security.Claims (4.3) - restriction: >= netcoreapp2.1
+    System.Security.Claims (4.3) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1345,7 +1345,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Security.Principal (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.Algorithms (4.3.1) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.Algorithms (4.3.1) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       runtime.native.System.Security.Cryptography.Apple (>= 4.3.1) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.2) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1360,8 +1360,8 @@ NUGET
       System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net463)
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net46) (< netstandard1.4)) (&& (>= net461) (< netstandard1.6)) (>= net463)
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Cryptography.Cng (4.5) - restriction: >= netcoreapp2.1
-    System.Security.Cryptography.Csp (4.3) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.Cng (4.5) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Csp (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1375,7 +1375,7 @@ NUGET
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.Encoding (4.3) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.Encoding (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1388,10 +1388,10 @@ NUGET
       System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.OpenSsl (4.5) - restriction: >= netcoreapp2.1
-    System.Security.Cryptography.Pkcs (4.5.1) - restriction: >= netcoreapp2.1
-      System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netcoreapp2.1
-    System.Security.Cryptography.Primitives (4.3) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.OpenSsl (4.5) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Pkcs (4.5.1) - restriction: >= netcoreapp3.0
+      System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Primitives (4.3) - restriction: >= netcoreapp3.0
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1399,7 +1399,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.X509Certificates (4.3.2) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.X509Certificates (4.3.2) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       runtime.native.System (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Net.Http (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1425,20 +1425,20 @@ NUGET
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Cryptography.Xml (4.5) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.Xml (4.5) - restriction: >= netcoreapp3.0
       System.Security.Cryptography.Pkcs (>= 4.5) - restriction: && (< net461) (>= netstandard2.0)
       System.Security.Permissions (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Security.Permissions (4.5) - restriction: >= netcoreapp2.1
+    System.Security.Permissions (4.5) - restriction: >= netcoreapp3.0
       System.Security.AccessControl (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Security.Principal (4.3) - restriction: >= netcoreapp2.1
+    System.Security.Principal (4.3) - restriction: >= netcoreapp3.0
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Principal.Windows (4.5.1) - restriction: >= netcoreapp2.1
+    System.Security.Principal.Windows (4.5.1) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
     System.Text.Encoding (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5)) (&& (< net45) (>= net461) (< netstandard1.5)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Text.Encoding.CodePages (4.5) - restriction: >= netcoreapp2.1
+    System.Text.Encoding.CodePages (4.5) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: || (&& (< net46) (>= netstandard2.0) (< xamarinios)) (>= net461) (>= netcoreapp2.0)
     System.Text.Encoding.Extensions (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
@@ -1446,7 +1446,7 @@ NUGET
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Text.Encodings.Web (4.5) - restriction: >= netcoreapp2.1
+    System.Text.Encodings.Web (4.5) - restriction: >= netcoreapp3.0
     System.Text.RegularExpressions (4.3) - restriction: || (>= net461) (>= netcoreapp1.0) (>= netstandard2.0)
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1457,13 +1457,13 @@ NUGET
     System.Threading (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Threading.Channels (4.5) - restriction: >= netcoreapp2.1
+    System.Threading.Channels (4.5) - restriction: >= netcoreapp3.0
     System.Threading.Tasks (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5)) (&& (< net45) (>= net461) (< netstandard1.5)) (&& (< net45) (>= net461) (>= netstandard1.6)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Threading.Tasks.Extensions (4.5.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp2.1)
-    System.Threading.Tasks.Parallel (4.3) - restriction: >= netcoreapp2.1
+    System.Threading.Tasks.Extensions (4.5.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.0)
+    System.Threading.Tasks.Parallel (4.3) - restriction: >= netcoreapp3.0
       System.Collections.Concurrent (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Tracing (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1477,7 +1477,7 @@ NUGET
     System.Threading.ThreadPool (4.3) - restriction: >= netcoreapp1.0
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Handles (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.ValueTuple (4.5) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.6) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.1)
+    System.ValueTuple (4.5) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.6) (>= netstandard2.0)) (>= net461) (>= netcoreapp3.0)
     System.Xml.ReaderWriter (4.3.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1546,7 +1546,7 @@ NUGET
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Xml.ReaderWriter (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Xml.XPath.XDocument (4.3) - restriction: >= netcoreapp2.1
+    System.Xml.XPath.XDocument (4.3) - restriction: >= netcoreapp3.0
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Linq (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)

--- a/src/content/DotLiquid/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
+++ b/src/content/DotLiquid/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>AppNamePlaceholder</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/content/DotLiquid/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
+++ b/src/content/DotLiquid/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>AppNamePlaceholder</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -9,8 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UsePaket)' == false OR '$(UsePaket)' == ''">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
-    <PackageReference Include="Giraffe" Version="3.4.*" />
+    <PackageReference Include="Giraffe" Version="4.0.*" />
     <PackageReference Include="Giraffe.DotLiquid" Version="1.2.*" />
     <PackageReference Include="TaskBuilder.fs" Version="2.1.*" />
   </ItemGroup>

--- a/src/content/DotLiquid/src/AppNamePlaceholder/Program.fs
+++ b/src/content/DotLiquid/src/AppNamePlaceholder/Program.fs
@@ -48,10 +48,10 @@ let configureCors (builder : CorsPolicyBuilder) =
            |> ignore
 
 let configureApp (app : IApplicationBuilder) =
-    let env = app.ApplicationServices.GetService<IHostingEnvironment>()
-    (match env.IsDevelopment() with
-    | true  -> app.UseDeveloperExceptionPage()
-    | false -> app.UseGiraffeErrorHandler(errorHandler))
+    let env = app.ApplicationServices.GetService<IWebHostEnvironment>()
+    (match env.EnvironmentName with
+    | "Development" -> app.UseDeveloperExceptionPage()
+    | _ -> app.UseGiraffeErrorHandler(errorHandler))
         .UseHttpsRedirection()
         .UseCors(configureCors)
         .UseStaticFiles()

--- a/src/content/DotLiquid/src/AppNamePlaceholder/paket.references
+++ b/src/content/DotLiquid/src/AppNamePlaceholder/paket.references
@@ -1,3 +1,2 @@
-Microsoft.AspNetCore.App
 Giraffe
 Giraffe.DotLiquid

--- a/src/content/DotLiquid/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
+++ b/src/content/DotLiquid/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UsePaket)' == false OR '$(UsePaket)' == ''">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.*" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.*" />
     <PackageReference Include="xunit" Version="2.4.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.*" />
   </ItemGroup>

--- a/src/content/DotLiquid/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
+++ b/src/content/DotLiquid/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UsePaket)' == false OR '$(UsePaket)' == ''">

--- a/src/content/Giraffe/paket.dependencies
+++ b/src/content/Giraffe/paket.dependencies
@@ -1,7 +1,6 @@
 storage: none
 source https://api.nuget.org/v3/index.json
 
-nuget Microsoft.AspNetCore.App
 nuget Giraffe
 nuget Microsoft.NET.Test.Sdk
 nuget Microsoft.AspNetCore.TestHost

--- a/src/content/Giraffe/paket.lock
+++ b/src/content/Giraffe/paket.lock
@@ -15,10 +15,10 @@ NUGET
       System.Xml.XmlSerializer (>= 4.3) - restriction: || (>= net461) (>= netstandard2.0)
       TaskBuilder.fs (>= 2.1) - restriction: || (>= net461) (>= netstandard2.0)
       Utf8Json (>= 1.3.7) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNet.WebApi.Client (5.2.6) - restriction: >= netcoreapp3.0
+    Microsoft.AspNet.WebApi.Client (5.2.6) - restriction: >= netcoreapp3.1
       Newtonsoft.Json (>= 10.0.1) - restriction: && (< net45) (>= netstandard2.0)
       Newtonsoft.Json.Bson (>= 1.0.1) - restriction: && (< net45) (>= netstandard2.0)
-    Microsoft.AspNetCore (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Diagnostics (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.HostFiltering (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
@@ -35,158 +35,158 @@ NUGET
       Microsoft.Extensions.Logging.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Console (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Debug (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Antiforgery (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Antiforgery (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.App (2.1.5)
-      Microsoft.AspNet.WebApi.Client (>= 5.2.6 < 5.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Antiforgery (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Facebook (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Google (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.JwtBearer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.MicrosoftAccount (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.OpenIdConnect (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Twitter (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.WsFederation (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authorization (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authorization.Policy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.CookiePolicy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Cors (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.DataProtection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.DataProtection.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Diagnostics (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.HostFiltering (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Connections (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Connections.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Features (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.HttpOverrides (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.HttpsPolicy (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Identity (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Identity.EntityFrameworkCore (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Identity.UI (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.JsonPatch (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Localization.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.MiddlewareAnalysis (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Analyzers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Formatters.Xml (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Localization (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.NodeServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Owin (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Razor.Design (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Razor.Language (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Razor.Runtime (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.ResponseCaching (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.ResponseCompression (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Rewrite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.HttpSys (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.IISIntegration (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.Kestrel (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Session (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SignalR (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SignalR.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SignalR.Core (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SpaServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SpaServices.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.StaticFiles (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.WebSockets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.WebUtilities (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.CodeAnalysis.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Design (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.InMemory (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Relational (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.SqlServer (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Tools (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Caching.Abstractions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Caching.Memory (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Caching.SqlServer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Binder (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.CommandLine (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Ini (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Json (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.KeyPerFile (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.UserSecrets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Xml (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.DependencyInjection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.DiagnosticAdapter (>= 2.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileProviders.Composite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Identity.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Identity.Stores (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Localization.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.Console (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.Debug (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.EventSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.TraceSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.ObjectPool (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Options (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Primitives (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.WebEncoders (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Net.Http.Headers (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      System.IO.Pipelines (>= 4.5.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNet.WebApi.Client (>= 5.2.6 < 5.3) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Antiforgery (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.Facebook (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.Google (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.JwtBearer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.MicrosoftAccount (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.OpenIdConnect (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.Twitter (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.WsFederation (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authorization (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authorization.Policy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.CookiePolicy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Cors (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.DataProtection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.DataProtection.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Diagnostics (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.HostFiltering (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Http.Connections (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Http.Connections.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Http.Features (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.HttpOverrides (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.HttpsPolicy (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Identity (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Identity.EntityFrameworkCore (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Identity.UI (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.JsonPatch (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Localization.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.MiddlewareAnalysis (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Analyzers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Formatters.Xml (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Localization (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.NodeServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Owin (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Razor.Design (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Razor.Language (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Razor.Runtime (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.ResponseCaching (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.ResponseCompression (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Rewrite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.HttpSys (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.IISIntegration (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.Kestrel (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Session (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.SignalR (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.SignalR.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.SignalR.Core (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.SpaServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.SpaServices.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.StaticFiles (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.WebSockets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.WebUtilities (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.CodeAnalysis.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.Design (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.InMemory (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.Relational (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.SqlServer (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.Tools (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Caching.Abstractions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Caching.Memory (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Caching.SqlServer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.Binder (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.CommandLine (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.Ini (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.Json (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.KeyPerFile (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.UserSecrets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.Xml (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.DependencyInjection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.DiagnosticAdapter (>= 2.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.FileProviders.Composite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Identity.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Identity.Stores (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Localization.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging.Console (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging.Debug (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging.EventSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging.TraceSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.ObjectPool (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Options (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Primitives (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.WebEncoders (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Net.Http.Headers (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      System.IO.Pipelines (>= 4.5.2) - restriction: >= netcoreapp3.1
     Microsoft.AspNetCore.Authentication (2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
@@ -195,60 +195,60 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.WebEncoders (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Cookies (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.Cookies (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Core (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.Core (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Facebook (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.Facebook (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Google (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.Google (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.JwtBearer (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.JwtBearer (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.OpenIdConnect (>= 5.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.MicrosoftAccount (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.MicrosoftAccount (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.OAuth (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.OAuth (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.OpenIdConnect (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.OpenIdConnect (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.OpenIdConnect (>= 5.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Twitter (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.Twitter (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.WsFederation (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.WsFederation (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.WsFederation (>= 5.2) - restriction: >= netstandard2.0
       System.IdentityModel.Tokens.Jwt (>= 5.2) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.Authorization (2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authorization.Policy (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authorization.Policy (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Authorization (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Connections.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Connections.Abstractions (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       System.IO.Pipelines (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.CookiePolicy (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.CookiePolicy (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cors (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Cors (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cryptography.Internal (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Cryptography.KeyDerivation (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Cryptography.Internal (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.AspNetCore.Cryptography.KeyDerivation (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.DataProtection (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.DataProtection (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -258,8 +258,8 @@ NUGET
       Microsoft.Win32.Registry (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Cryptography.Xml (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.DataProtection.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.DataProtection.Extensions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.DataProtection.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.AspNetCore.DataProtection.Extensions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.Diagnostics (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -272,11 +272,11 @@ NUGET
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
       System.Reflection.Metadata (>= 1.6) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Diagnostics.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Diagnostics.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HostFiltering (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.HostFiltering (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -299,21 +299,21 @@ NUGET
       Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Html.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Html.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Http (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Http.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Connections (1.0.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Http.Connections (1.0.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authorization.Policy (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
@@ -321,58 +321,58 @@ NUGET
       Microsoft.AspNetCore.Routing (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebSockets (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Connections.Common (1.0.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Http.Connections.Common (1.0.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Extensions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Http.Extensions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Features (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Http.Features (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HttpOverrides (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.HttpOverrides (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HttpsPolicy (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.HttpsPolicy (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Identity (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity.EntityFrameworkCore (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Identity.EntityFrameworkCore (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Identity (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Stores (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity.UI (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Identity.UI (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Identity (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.StaticFiles (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Stores (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.JsonPatch (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.JsonPatch (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.CSharp (>= 4.5) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Localization (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Localization (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Localization.Routing (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Localization.Routing (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.MiddlewareAnalysis (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.MiddlewareAnalysis (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3) - restriction: >= netstandard2.0
@@ -385,13 +385,13 @@ NUGET
       Microsoft.AspNetCore.Razor.Design (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Abstractions (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Analyzers (2.1.3) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Mvc.ApiExplorer (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Analyzers (2.1.3) - restriction: >= netcoreapp3.1
+    Microsoft.AspNetCore.Mvc.ApiExplorer (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Core (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Core (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Authorization.Policy (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -406,24 +406,24 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5.1) - restriction: >= netstandard2.0
       System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Cors (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Cors (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Cors (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.DataAnnotations (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.DataAnnotations (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Formatters.Json (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Formatters.Json (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.JsonPatch (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Formatters.Xml (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Formatters.Xml (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Localization (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Localization (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Razor (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Razor (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Razor.Runtime (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -431,22 +431,22 @@ NUGET
       Microsoft.CodeAnalysis.Razor (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.FileProviders.Composite (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNetCore.Mvc.Razor.Extensions (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Razor.Extensions (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Razor.Language (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.Razor (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
-    Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: || (>= net461) (>= netcoreapp2.0)
       Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.1) - restriction: || (>= net461) (>= netcoreapp2.0)
-    Microsoft.AspNetCore.Mvc.RazorPages (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.RazorPages (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.TagHelpers (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.TagHelpers (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Razor.Runtime (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.ViewFeatures (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.ViewFeatures (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Antiforgery (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -455,17 +455,17 @@ NUGET
       Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.WebEncoders (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json.Bson (>= 1.0.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.NodeServices (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.NodeServices (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Console (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Owin (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Owin (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Razor (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor.Design (2.1.2) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Razor.Language (2.1.2) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Razor.Runtime (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Razor.Design (2.1.2) - restriction: >= netcoreapp3.1
+    Microsoft.AspNetCore.Razor.Language (2.1.2) - restriction: >= netcoreapp3.1
+    Microsoft.AspNetCore.Razor.Runtime (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Razor (>= 2.1.2) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.ResponseCaching (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -474,33 +474,33 @@ NUGET
       Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCompression (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.ResponseCompression (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNetCore.Rewrite (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Rewrite (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Routing (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Routing (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Routing.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Routing.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.HttpSys (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.HttpSys (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Win32.Registry (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.IISIntegration (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.IISIntegration (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
@@ -514,12 +514,12 @@ NUGET
       System.Numerics.Vectors (>= 4.5) - restriction: >= netstandard2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5.2) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.Kestrel (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Core (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.Kestrel.Core (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
@@ -532,30 +532,30 @@ NUGET
       System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
       System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netstandard2.0
       System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Https (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.Kestrel.Https (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Session (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Session (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR (1.0.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.SignalR (1.0.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Connections (>= 1.0.4) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Core (>= 1.0.4) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Common (1.0.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.SignalR.Common (1.0.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Core (1.0.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.SignalR.Core (1.0.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authorization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Common (>= 1.0.4) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4) - restriction: >= netstandard2.0
@@ -563,19 +563,19 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Reflection.Emit (>= 4.3) - restriction: >= netstandard2.0
       System.Threading.Channels (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Protocols.Json (1.0.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.SignalR.Protocols.Json (1.0.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.SignalR.Common (>= 1.0.4) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SpaServices (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.SpaServices (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.NodeServices (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SpaServices.Extensions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.SpaServices.Extensions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.SpaServices (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.StaticFiles (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebSockets (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.StaticFiles (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.StaticFiles (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -584,15 +584,15 @@ NUGET
     Microsoft.AspNetCore.TestHost (2.1.1)
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       System.IO.Pipelines (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.WebSockets (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.WebSockets (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Net.WebSockets.WebSocketProtocol (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.WebUtilities (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.WebUtilities (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.CodeAnalysis.Analyzers (2.6.2) - restriction: >= netcoreapp3.0
-    Microsoft.CodeAnalysis.Common (2.9) - restriction: >= netcoreapp3.0
+    Microsoft.CodeAnalysis.Analyzers (2.6.2) - restriction: >= netcoreapp3.1
+    Microsoft.CodeAnalysis.Common (2.9) - restriction: >= netcoreapp3.1
       Microsoft.CodeAnalysis.Analyzers (>= 2.6.1) - restriction: >= netstandard1.3
       System.AppContext (>= 4.3) - restriction: >= netstandard1.3
       System.Collections (>= 4.3) - restriction: >= netstandard1.3
@@ -633,15 +633,15 @@ NUGET
       System.Xml.XDocument (>= 4.3) - restriction: >= netstandard1.3
       System.Xml.XmlDocument (>= 4.3) - restriction: >= netstandard1.3
       System.Xml.XPath.XDocument (>= 4.3) - restriction: >= netstandard1.3
-    Microsoft.CodeAnalysis.CSharp (2.9) - restriction: >= netcoreapp3.0
+    Microsoft.CodeAnalysis.CSharp (2.9) - restriction: >= netcoreapp3.1
       Microsoft.CodeAnalysis.Common (2.9)
-    Microsoft.CodeAnalysis.Razor (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.CodeAnalysis.Razor (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Razor.Language (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.Common (>= 2.8) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.CSharp (>= 2.8) - restriction: || (>= net46) (>= netstandard2.0)
     Microsoft.CodeCoverage (15.9) - restriction: || (>= net45) (>= netcoreapp1.0)
-    Microsoft.CSharp (4.5) - restriction: >= netcoreapp3.0
-    Microsoft.DotNet.PlatformAbstractions (2.1) - restriction: >= netcoreapp3.0
+    Microsoft.CSharp (4.5) - restriction: >= netcoreapp3.1
+    Microsoft.DotNet.PlatformAbstractions (2.1) - restriction: >= netcoreapp3.1
       System.AppContext (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Collections (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.3)
       System.IO (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
@@ -650,7 +650,7 @@ NUGET
       System.Runtime.Extensions (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Runtime.InteropServices (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Runtime.InteropServices.RuntimeInformation (>= 4.0) - restriction: || (>= net45) (>= netstandard1.3)
-    Microsoft.EntityFrameworkCore (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
@@ -661,171 +661,171 @@ NUGET
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5.1) - restriction: >= netstandard2.0
       System.Interactive.Async (>= 3.1.1) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Abstractions (2.1.4) - restriction: >= netcoreapp3.0
-    Microsoft.EntityFrameworkCore.Analyzers (2.1.4) - restriction: >= netcoreapp3.0
-    Microsoft.EntityFrameworkCore.Design (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.Abstractions (2.1.4) - restriction: >= netcoreapp3.1
+    Microsoft.EntityFrameworkCore.Analyzers (2.1.4) - restriction: >= netcoreapp3.1
+    Microsoft.EntityFrameworkCore.Design (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.CSharp (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.4) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.EntityFrameworkCore.InMemory (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.InMemory (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.EntityFrameworkCore (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Relational (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.Relational (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.EntityFrameworkCore (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.SqlServer (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.SqlServer (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.4) - restriction: >= netstandard2.0
       System.Data.SqlClient (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Tools (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.Tools (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.EntityFrameworkCore.Design (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.Abstractions (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Caching.Abstractions (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.Memory (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Caching.Memory (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.SqlServer (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Caching.SqlServer (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Data.SqlClient (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Binder (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.Binder (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.CommandLine (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.CommandLine (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.EnvironmentVariables (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.EnvironmentVariables (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.FileExtensions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.FileExtensions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Ini (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.Ini (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Json (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.Json (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.KeyPerFile (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.KeyPerFile (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.UserSecrets (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.UserSecrets (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration.Json (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Xml (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.Xml (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Security.Cryptography.Xml (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.DependencyInjection (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.DependencyInjection (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.DependencyInjection.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.DependencyInjection.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
     Microsoft.Extensions.DependencyModel (2.1) - restriction: >= netcoreapp1.0
       Microsoft.DotNet.PlatformAbstractions (>= 2.1) - restriction: || (>= net451) (>= netstandard1.3)
       Newtonsoft.Json (>= 9.0.1) - restriction: || (>= net451) (>= netstandard1.3)
       System.Diagnostics.Debug (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
       System.Dynamic.Runtime (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
       System.Linq (>= 4.1) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
-    Microsoft.Extensions.DiagnosticAdapter (2.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.DiagnosticAdapter (2.1) - restriction: >= netcoreapp3.1
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.FileProviders.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.FileProviders.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Composite (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.FileProviders.Composite (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Embedded (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.FileProviders.Embedded (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Physical (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.FileProviders.Physical (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileSystemGlobbing (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.Extensions.Hosting (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.FileSystemGlobbing (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.Extensions.Hosting (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Hosting.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Hosting.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Http (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Http (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Identity.Core (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Identity.Core (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Identity.Stores (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Identity.Stores (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Identity.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Localization (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Localization (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Localization.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.Extensions.Logging (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Localization.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.Extensions.Logging (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.Extensions.Logging.Configuration (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.Extensions.Logging.Configuration (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Console (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging.Console (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Debug (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging.Debug (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.EventSource (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging.EventSource (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.TraceSource (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging.TraceSource (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.ObjectPool (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.Extensions.Options (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.ObjectPool (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.Extensions.Options (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Options.ConfigurationExtensions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Options.ConfigurationExtensions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Primitives (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Primitives (2.1.1) - restriction: >= netcoreapp3.1
       System.Memory (>= 4.5.1) - restriction: >= netstandard2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.WebEncoders (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.WebEncoders (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.IdentityModel.JsonWebTokens (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.JsonWebTokens (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Logging (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Logging (5.3) - restriction: >= netcoreapp3.1
       System.Diagnostics.Tracing (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Globalization (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IO (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IO.FileSystem (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Protocols (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Protocols (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Logging (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Collections.Specialized (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Diagnostics.Contracts (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Net.Http (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Protocols.OpenIdConnect (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Protocols.OpenIdConnect (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Protocols (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Dynamic.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IdentityModel.Tokens.Jwt (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Protocols.WsFederation (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Protocols.WsFederation (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Protocols (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens.Saml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Xml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Xml.XmlDocument (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Tokens (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Tokens (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Logging (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Collections (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
@@ -841,12 +841,12 @@ NUGET
       System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Text.RegularExpressions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Threading (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Tokens.Saml (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Tokens.Saml (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Xml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Xml (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Xml (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.Net.Http.Headers (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Net.Http.Headers (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
     Microsoft.NET.Test.Sdk (15.9)
@@ -887,10 +887,10 @@ NUGET
     NETStandard.Library (2.0.3) - restriction: || (&& (< net35) (>= netstandard1.1) (< netstandard2.0)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= netstandard2.0)) (&& (< net452) (>= netstandard1.1)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (>= net45) (< netstandard1.3)) (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.4)) (>= net461) (>= netcoreapp2.0) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8) (< win8)) (&& (< netstandard1.0) (< portable-net45+win8) (>= portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard1.3) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= uap10.0)) (>= uap10.1) (>= wp8)
     Newtonsoft.Json (11.0.2) - restriction: || (>= net461) (>= netcoreapp1.0) (>= netstandard2.0) (>= uap10.0)
-    Newtonsoft.Json.Bson (1.0.1) - restriction: >= netcoreapp3.0
+    Newtonsoft.Json.Bson (1.0.1) - restriction: >= netcoreapp3.1
       NETStandard.Library (>= 1.6.1) - restriction: && (< net45) (>= netstandard1.3)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (>= net45) (>= netstandard1.3)
-    Remotion.Linq (2.2) - restriction: >= netcoreapp3.0
+    Remotion.Linq (2.2) - restriction: >= netcoreapp3.1
       System.Collections (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
       System.Diagnostics.Debug (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
       System.Linq (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
@@ -902,28 +902,28 @@ NUGET
       System.Runtime (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
       System.Runtime.Extensions (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
       System.Threading (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
-    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
     runtime.native.System (4.3.1) - restriction: >= netcoreapp1.0
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Data.SqlClient.sni (4.5) - restriction: >= netcoreapp3.0
+    runtime.native.System.Data.SqlClient.sni (4.5) - restriction: >= netcoreapp3.1
       runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (>= 4.4)
       runtime.win-x64.runtime.native.System.Data.SqlClient.sni (>= 4.4)
       runtime.win-x86.runtime.native.System.Data.SqlClient.sni (>= 4.4)
-    runtime.native.System.IO.Compression (4.3.2) - restriction: >= netcoreapp3.0
+    runtime.native.System.IO.Compression (4.3.2) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Net.Http (4.3.1) - restriction: >= netcoreapp3.0
+    runtime.native.System.Net.Http (4.3.1) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.0
+    runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.1
       runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (>= 4.3.1)
-    runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
       runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
@@ -939,22 +939,22 @@ NUGET
       runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.0
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
-    runtime.win-x64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
-    runtime.win-x86.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
-    System.AppContext (4.3) - restriction: >= netcoreapp3.0
+    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.1
+    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.1
+    runtime.win-x64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.1
+    runtime.win-x86.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.1
+    System.AppContext (4.3) - restriction: >= netcoreapp3.1
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Buffers (4.5) - restriction: >= netcoreapp3.0
+    System.Buffers (4.5) - restriction: >= netcoreapp3.1
     System.Collections (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -970,15 +970,15 @@ NUGET
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
-    System.Collections.Immutable (1.5) - restriction: >= netcoreapp3.0
-    System.Collections.NonGeneric (4.3) - restriction: >= netcoreapp3.0
+    System.Collections.Immutable (1.5) - restriction: >= netcoreapp3.1
+    System.Collections.NonGeneric (4.3) - restriction: >= netcoreapp3.1
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Collections.Specialized (4.3) - restriction: >= netcoreapp3.0
+    System.Collections.Specialized (4.3) - restriction: >= netcoreapp3.1
       System.Collections.NonGeneric (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -986,7 +986,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.ComponentModel.Annotations (4.5) - restriction: >= netcoreapp3.0
+    System.ComponentModel.Annotations (4.5) - restriction: >= netcoreapp3.1
     System.ComponentModel.EventBasedAsync (4.3) - restriction: >= netcoreapp1.0
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -995,25 +995,25 @@ NUGET
     System.ComponentModel.Primitives (4.3) - restriction: >= uap10.0
     System.ComponentModel.TypeConverter (4.3) - restriction: || (>= netcoreapp1.0) (>= uap10.0)
       System.ComponentModel.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.5) (< win8)) (&& (>= net45) (< netstandard1.5)) (>= net462) (&& (< netstandard1.0) (>= win8)) (>= wp8) (>= wpa81)
-    System.Console (4.3.1) - restriction: >= netcoreapp3.0
+    System.Console (4.3.1) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1.2) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Data.SqlClient (4.5.1) - restriction: >= netcoreapp3.0
+    System.Data.SqlClient (4.5.1) - restriction: >= netcoreapp3.1
       Microsoft.Win32.Registry (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       runtime.native.System.Data.SqlClient.sni (>= 4.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net451) (>= netstandard1.3) (< netstandard2.0) (< win81) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       System.Security.Principal.Windows (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       System.Text.Encoding.CodePages (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
-    System.Diagnostics.Contracts (4.3) - restriction: >= netcoreapp3.0
+    System.Diagnostics.Contracts (4.3) - restriction: >= netcoreapp3.1
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
     System.Diagnostics.Debug (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (>= netstandard1.6)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Diagnostics.DiagnosticSource (4.5.1) - restriction: >= netcoreapp3.0
-    System.Diagnostics.FileVersionInfo (4.3) - restriction: >= netcoreapp3.0
+    System.Diagnostics.DiagnosticSource (4.5.1) - restriction: >= netcoreapp3.1
+    System.Diagnostics.FileVersionInfo (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1045,7 +1045,7 @@ NUGET
       System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.Thread (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.ThreadPool (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.StackTrace (4.3) - restriction: >= netcoreapp3.0
+    System.Diagnostics.StackTrace (4.3) - restriction: >= netcoreapp3.1
       System.IO.FileSystem (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection.Metadata (>= 1.4.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1057,7 +1057,7 @@ NUGET
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.Tools (4.3) - restriction: >= netcoreapp3.0
+    System.Diagnostics.Tools (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1071,11 +1071,11 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.Tracing (4.3) - restriction: >= netcoreapp3.0
+    System.Diagnostics.Tracing (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Dynamic.Runtime (4.3) - restriction: >= netcoreapp3.0
+    System.Dynamic.Runtime (4.3) - restriction: >= netcoreapp3.1
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Linq (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1094,30 +1094,30 @@ NUGET
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Globalization.Calendars (4.3) - restriction: >= netcoreapp3.0
+    System.Globalization.Calendars (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Globalization.Extensions (4.3) - restriction: >= netcoreapp3.0
+    System.Globalization.Extensions (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.IdentityModel.Tokens.Jwt (5.3) - restriction: >= netcoreapp3.0
+    System.IdentityModel.Tokens.Jwt (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.JsonWebTokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    System.Interactive.Async (3.2) - restriction: >= netcoreapp3.0
+    System.Interactive.Async (3.2) - restriction: >= netcoreapp3.1
     System.IO (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.IO.Compression (4.3) - restriction: >= netcoreapp3.0
+    System.IO.Compression (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.IO.Compression (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1151,7 +1151,7 @@ NUGET
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.6) (< win8) (< wp8) (< wpa81))
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Linq.Expressions (4.3) - restriction: >= netcoreapp3.0
+    System.Linq.Expressions (4.3) - restriction: >= netcoreapp3.1
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1169,7 +1169,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Linq.Queryable (4.3) - restriction: >= netcoreapp3.0
+    System.Linq.Queryable (4.3) - restriction: >= netcoreapp3.1
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Linq (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -1178,8 +1178,8 @@ NUGET
       System.Reflection.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Memory (4.5.1) - restriction: >= netcoreapp3.0
-    System.Net.Http (4.3.4) - restriction: >= netcoreapp3.0
+    System.Memory (4.5.1) - restriction: >= netcoreapp3.1
+    System.Net.Http (4.3.4) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Net.Http (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1206,14 +1206,14 @@ NUGET
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-    System.Net.Primitives (4.3) - restriction: >= netcoreapp3.0
+    System.Net.Primitives (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       System.Runtime.Handles (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Net.WebSockets.WebSocketProtocol (4.5.2) - restriction: >= netcoreapp3.0
-    System.Numerics.Vectors (4.5) - restriction: >= netcoreapp3.0
-    System.ObjectModel (4.3) - restriction: >= netcoreapp3.0
+    System.Net.WebSockets.WebSocketProtocol (4.5.2) - restriction: >= netcoreapp3.1
+    System.Numerics.Vectors (4.5) - restriction: >= netcoreapp3.1
+    System.ObjectModel (4.3) - restriction: >= netcoreapp3.1
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1251,7 +1251,7 @@ NUGET
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Reflection.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Reflection.Emit (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.0)
+    System.Reflection.Emit (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.1)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1286,7 +1286,7 @@ NUGET
     System.Runtime (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= net461) (< netstandard1.6)) (&& (< net45) (>= net461) (< netstandard2.0)) (&& (< net45) (>= net47)) (&& (>= net461) (>= netcoreapp1.1)) (>= netcoreapp1.0) (&& (>= netcoreapp1.1) (>= netstandard2.0))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Runtime.CompilerServices.Unsafe (4.5.2) - restriction: >= netcoreapp3.0
+    System.Runtime.CompilerServices.Unsafe (4.5.2) - restriction: >= netcoreapp3.1
     System.Runtime.Extensions (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
@@ -1307,7 +1307,7 @@ NUGET
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Runtime.Numerics (4.3) - restriction: >= netcoreapp3.0
+    System.Runtime.Numerics (4.3) - restriction: >= netcoreapp3.1
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
@@ -1319,17 +1319,17 @@ NUGET
     System.Runtime.Serialization.Primitives (4.3) - restriction: >= netcoreapp1.0
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Runtime.Serialization.Xml (4.3) - restriction: >= netcoreapp3.0
+    System.Runtime.Serialization.Xml (4.3) - restriction: >= netcoreapp3.1
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Private.DataContractSerialization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime.Serialization.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Xml.ReaderWriter (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Security.AccessControl (4.5) - restriction: >= netcoreapp3.0
+    System.Security.AccessControl (4.5) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: || (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0)
-    System.Security.Claims (4.3) - restriction: >= netcoreapp3.0
+    System.Security.Claims (4.3) - restriction: >= netcoreapp3.1
       System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1337,7 +1337,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Security.Principal (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.Algorithms (4.3.1) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Algorithms (4.3.1) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       runtime.native.System.Security.Cryptography.Apple (>= 4.3.1) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.2) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1352,8 +1352,8 @@ NUGET
       System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net463)
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net46) (< netstandard1.4)) (&& (>= net461) (< netstandard1.6)) (>= net463)
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Cryptography.Cng (4.5) - restriction: >= netcoreapp3.0
-    System.Security.Cryptography.Csp (4.3) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Cng (4.5) - restriction: >= netcoreapp3.1
+    System.Security.Cryptography.Csp (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1367,7 +1367,7 @@ NUGET
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.Encoding (4.3) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Encoding (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1380,10 +1380,10 @@ NUGET
       System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.OpenSsl (4.5) - restriction: >= netcoreapp3.0
-    System.Security.Cryptography.Pkcs (4.5.1) - restriction: >= netcoreapp3.0
-      System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netcoreapp3.0
-    System.Security.Cryptography.Primitives (4.3) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.OpenSsl (4.5) - restriction: >= netcoreapp3.1
+    System.Security.Cryptography.Pkcs (4.5.1) - restriction: >= netcoreapp3.1
+      System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netcoreapp3.1
+    System.Security.Cryptography.Primitives (4.3) - restriction: >= netcoreapp3.1
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1391,7 +1391,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.X509Certificates (4.3.2) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.X509Certificates (4.3.2) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       runtime.native.System (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Net.Http (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1417,20 +1417,20 @@ NUGET
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Cryptography.Xml (4.5) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Xml (4.5) - restriction: >= netcoreapp3.1
       System.Security.Cryptography.Pkcs (>= 4.5) - restriction: && (< net461) (>= netstandard2.0)
       System.Security.Permissions (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Security.Permissions (4.5) - restriction: >= netcoreapp3.0
+    System.Security.Permissions (4.5) - restriction: >= netcoreapp3.1
       System.Security.AccessControl (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Security.Principal (4.3) - restriction: >= netcoreapp3.0
+    System.Security.Principal (4.3) - restriction: >= netcoreapp3.1
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Principal.Windows (4.5.1) - restriction: >= netcoreapp3.0
+    System.Security.Principal.Windows (4.5.1) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
     System.Text.Encoding (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5)) (&& (< net45) (>= net461) (< netstandard1.5)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Text.Encoding.CodePages (4.5) - restriction: >= netcoreapp3.0
+    System.Text.Encoding.CodePages (4.5) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: || (&& (< net46) (>= netstandard2.0) (< xamarinios)) (>= net461) (>= netcoreapp2.0)
     System.Text.Encoding.Extensions (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
@@ -1438,7 +1438,7 @@ NUGET
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Text.Encodings.Web (4.5) - restriction: >= netcoreapp3.0
+    System.Text.Encodings.Web (4.5) - restriction: >= netcoreapp3.1
     System.Text.RegularExpressions (4.3) - restriction: || (>= net461) (>= netcoreapp1.0) (>= netstandard2.0)
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1449,13 +1449,13 @@ NUGET
     System.Threading (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Threading.Channels (4.5) - restriction: >= netcoreapp3.0
+    System.Threading.Channels (4.5) - restriction: >= netcoreapp3.1
     System.Threading.Tasks (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5)) (&& (< net45) (>= net461) (< netstandard1.5)) (&& (< net45) (>= net461) (>= netstandard1.6)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Threading.Tasks.Extensions (4.5.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.0)
-    System.Threading.Tasks.Parallel (4.3) - restriction: >= netcoreapp3.0
+    System.Threading.Tasks.Extensions (4.5.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.1)
+    System.Threading.Tasks.Parallel (4.3) - restriction: >= netcoreapp3.1
       System.Collections.Concurrent (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Tracing (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1469,7 +1469,7 @@ NUGET
     System.Threading.ThreadPool (4.3) - restriction: >= netcoreapp1.0
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Handles (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.ValueTuple (4.5) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.6) (>= netstandard2.0)) (>= net461) (>= netcoreapp3.0)
+    System.ValueTuple (4.5) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.6) (>= netstandard2.0)) (>= net461) (>= netcoreapp3.1)
     System.Xml.ReaderWriter (4.3.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1538,7 +1538,7 @@ NUGET
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Xml.ReaderWriter (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Xml.XPath.XDocument (4.3) - restriction: >= netcoreapp3.0
+    System.Xml.XPath.XDocument (4.3) - restriction: >= netcoreapp3.1
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Linq (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)

--- a/src/content/Giraffe/paket.lock
+++ b/src/content/Giraffe/paket.lock
@@ -15,10 +15,10 @@ NUGET
       System.Xml.XmlSerializer (>= 4.3) - restriction: || (>= net461) (>= netstandard2.0)
       TaskBuilder.fs (>= 2.1) - restriction: || (>= net461) (>= netstandard2.0)
       Utf8Json (>= 1.3.7) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNet.WebApi.Client (5.2.6) - restriction: >= netcoreapp2.1
+    Microsoft.AspNet.WebApi.Client (5.2.6) - restriction: >= netcoreapp3.0
       Newtonsoft.Json (>= 10.0.1) - restriction: && (< net45) (>= netstandard2.0)
       Newtonsoft.Json.Bson (>= 1.0.1) - restriction: && (< net45) (>= netstandard2.0)
-    Microsoft.AspNetCore (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Diagnostics (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.HostFiltering (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
@@ -35,158 +35,158 @@ NUGET
       Microsoft.Extensions.Logging.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Console (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Debug (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Antiforgery (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Antiforgery (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.App (2.1.5)
-      Microsoft.AspNet.WebApi.Client (>= 5.2.6 < 5.3) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Antiforgery (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Facebook (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Google (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.JwtBearer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.MicrosoftAccount (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.OpenIdConnect (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Twitter (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.WsFederation (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authorization (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authorization.Policy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.CookiePolicy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Cors (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.DataProtection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.DataProtection.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Diagnostics (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.HostFiltering (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http.Connections (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http.Connections.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http.Features (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.HttpOverrides (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.HttpsPolicy (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Identity (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Identity.EntityFrameworkCore (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Identity.UI (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.JsonPatch (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Localization.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.MiddlewareAnalysis (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Analyzers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Formatters.Xml (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Localization (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.NodeServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Owin (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Razor.Design (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Razor.Language (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Razor.Runtime (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.ResponseCaching (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.ResponseCompression (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Rewrite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.HttpSys (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.IISIntegration (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.Kestrel (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Session (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SignalR (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SignalR.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SignalR.Core (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SpaServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SpaServices.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.StaticFiles (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.WebSockets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.WebUtilities (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.CodeAnalysis.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.Design (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.InMemory (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.Relational (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.SqlServer (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.Tools (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Caching.Abstractions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Caching.Memory (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Caching.SqlServer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.Binder (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.CommandLine (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.Ini (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.Json (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.KeyPerFile (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.UserSecrets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.Xml (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.DependencyInjection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.DiagnosticAdapter (>= 2.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.FileProviders.Composite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Identity.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Identity.Stores (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Localization.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.Console (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.Debug (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.EventSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.TraceSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.ObjectPool (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Options (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Primitives (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.WebEncoders (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Net.Http.Headers (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      System.IO.Pipelines (>= 4.5.2) - restriction: >= netcoreapp2.1
+      Microsoft.AspNet.WebApi.Client (>= 5.2.6 < 5.3) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Antiforgery (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Facebook (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Google (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.JwtBearer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.MicrosoftAccount (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.OpenIdConnect (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Twitter (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.WsFederation (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authorization (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authorization.Policy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.CookiePolicy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Cors (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.DataProtection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.DataProtection.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Diagnostics (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.HostFiltering (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http.Connections (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http.Connections.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http.Features (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.HttpOverrides (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.HttpsPolicy (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Identity (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Identity.EntityFrameworkCore (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Identity.UI (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.JsonPatch (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Localization.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.MiddlewareAnalysis (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Analyzers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Formatters.Xml (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Localization (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.NodeServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Owin (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Razor.Design (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Razor.Language (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Razor.Runtime (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.ResponseCaching (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.ResponseCompression (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Rewrite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.HttpSys (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.IISIntegration (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.Kestrel (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Session (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SignalR (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SignalR.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SignalR.Core (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SpaServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SpaServices.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.StaticFiles (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.WebSockets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.WebUtilities (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.CodeAnalysis.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.Design (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.InMemory (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.Relational (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.SqlServer (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.Tools (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Caching.Abstractions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Caching.Memory (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Caching.SqlServer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.Binder (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.CommandLine (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.Ini (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.Json (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.KeyPerFile (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.UserSecrets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.Xml (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.DependencyInjection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.DiagnosticAdapter (>= 2.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.FileProviders.Composite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Identity.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Identity.Stores (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Localization.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.Console (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.Debug (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.EventSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.TraceSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.ObjectPool (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Options (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Primitives (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.WebEncoders (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Net.Http.Headers (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      System.IO.Pipelines (>= 4.5.2) - restriction: >= netcoreapp3.0
     Microsoft.AspNetCore.Authentication (2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
@@ -195,60 +195,60 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.WebEncoders (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Cookies (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Cookies (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Core (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Core (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Facebook (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Facebook (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Google (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Google (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.JwtBearer (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.JwtBearer (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.OpenIdConnect (>= 5.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.MicrosoftAccount (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.MicrosoftAccount (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.OAuth (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.OAuth (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.OpenIdConnect (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.OpenIdConnect (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.OpenIdConnect (>= 5.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Twitter (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Twitter (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.WsFederation (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.WsFederation (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.WsFederation (>= 5.2) - restriction: >= netstandard2.0
       System.IdentityModel.Tokens.Jwt (>= 5.2) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.Authorization (2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authorization.Policy (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authorization.Policy (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Authorization (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Connections.Abstractions (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Connections.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       System.IO.Pipelines (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.CookiePolicy (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.CookiePolicy (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cors (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Cors (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cryptography.Internal (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.Cryptography.KeyDerivation (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Cryptography.Internal (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Cryptography.KeyDerivation (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.DataProtection (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.DataProtection (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -258,8 +258,8 @@ NUGET
       Microsoft.Win32.Registry (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Cryptography.Xml (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.DataProtection.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.DataProtection.Extensions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.DataProtection.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.DataProtection.Extensions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.Diagnostics (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -272,11 +272,11 @@ NUGET
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
       System.Reflection.Metadata (>= 1.6) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Diagnostics.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Diagnostics.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HostFiltering (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.HostFiltering (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -299,21 +299,21 @@ NUGET
       Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Html.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Html.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Connections (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http.Connections (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authorization.Policy (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
@@ -321,58 +321,58 @@ NUGET
       Microsoft.AspNetCore.Routing (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebSockets (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Connections.Common (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http.Connections.Common (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Extensions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http.Extensions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Features (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http.Features (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HttpOverrides (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.HttpOverrides (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HttpsPolicy (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.HttpsPolicy (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Identity (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity.EntityFrameworkCore (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Identity.EntityFrameworkCore (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Identity (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Stores (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity.UI (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Identity.UI (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Identity (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.StaticFiles (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Stores (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.JsonPatch (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.JsonPatch (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.CSharp (>= 4.5) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Localization (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Localization (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Localization.Routing (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Localization.Routing (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.MiddlewareAnalysis (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.MiddlewareAnalysis (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3) - restriction: >= netstandard2.0
@@ -385,13 +385,13 @@ NUGET
       Microsoft.AspNetCore.Razor.Design (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Abstractions (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Analyzers (2.1.3) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.Mvc.ApiExplorer (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Analyzers (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.ApiExplorer (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Core (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Core (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Authorization.Policy (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -406,24 +406,24 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5.1) - restriction: >= netstandard2.0
       System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Cors (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Cors (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Cors (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.DataAnnotations (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.DataAnnotations (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Formatters.Json (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Formatters.Json (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.JsonPatch (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Formatters.Xml (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Formatters.Xml (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Localization (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Localization (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Razor (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Razor (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Razor.Runtime (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -431,22 +431,22 @@ NUGET
       Microsoft.CodeAnalysis.Razor (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.FileProviders.Composite (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNetCore.Mvc.Razor.Extensions (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Razor.Extensions (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Razor.Language (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.Razor (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
-    Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: || (>= net461) (>= netcoreapp2.0)
       Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.1) - restriction: || (>= net461) (>= netcoreapp2.0)
-    Microsoft.AspNetCore.Mvc.RazorPages (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.RazorPages (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.TagHelpers (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.TagHelpers (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Razor.Runtime (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.ViewFeatures (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.ViewFeatures (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Antiforgery (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -455,17 +455,17 @@ NUGET
       Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.WebEncoders (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json.Bson (>= 1.0.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.NodeServices (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.NodeServices (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Console (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Owin (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Owin (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Razor (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor.Design (2.1.2) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.Razor.Language (2.1.2) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.Razor.Runtime (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Razor.Design (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Razor.Language (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Razor.Runtime (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Razor (>= 2.1.2) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.ResponseCaching (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -474,33 +474,33 @@ NUGET
       Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCompression (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.ResponseCompression (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNetCore.Rewrite (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Rewrite (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Routing (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Routing (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Routing.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Routing.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.HttpSys (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.HttpSys (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Win32.Registry (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.IISIntegration (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.IISIntegration (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
@@ -514,12 +514,12 @@ NUGET
       System.Numerics.Vectors (>= 4.5) - restriction: >= netstandard2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5.2) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.Kestrel (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Core (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.Kestrel.Core (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
@@ -532,30 +532,30 @@ NUGET
       System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
       System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netstandard2.0
       System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Https (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.Kestrel.Https (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Session (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Session (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SignalR (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Connections (>= 1.0.4) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Core (>= 1.0.4) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Common (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SignalR.Common (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Core (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SignalR.Core (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authorization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Common (>= 1.0.4) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4) - restriction: >= netstandard2.0
@@ -563,19 +563,19 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Reflection.Emit (>= 4.3) - restriction: >= netstandard2.0
       System.Threading.Channels (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Protocols.Json (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SignalR.Protocols.Json (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.SignalR.Common (>= 1.0.4) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SpaServices (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SpaServices (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.NodeServices (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SpaServices.Extensions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SpaServices.Extensions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.SpaServices (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.StaticFiles (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebSockets (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.StaticFiles (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.StaticFiles (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -584,15 +584,15 @@ NUGET
     Microsoft.AspNetCore.TestHost (2.1.1)
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       System.IO.Pipelines (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.WebSockets (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.WebSockets (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Net.WebSockets.WebSocketProtocol (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.WebUtilities (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.WebUtilities (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.CodeAnalysis.Analyzers (2.6.2) - restriction: >= netcoreapp2.1
-    Microsoft.CodeAnalysis.Common (2.9) - restriction: >= netcoreapp2.1
+    Microsoft.CodeAnalysis.Analyzers (2.6.2) - restriction: >= netcoreapp3.0
+    Microsoft.CodeAnalysis.Common (2.9) - restriction: >= netcoreapp3.0
       Microsoft.CodeAnalysis.Analyzers (>= 2.6.1) - restriction: >= netstandard1.3
       System.AppContext (>= 4.3) - restriction: >= netstandard1.3
       System.Collections (>= 4.3) - restriction: >= netstandard1.3
@@ -633,15 +633,15 @@ NUGET
       System.Xml.XDocument (>= 4.3) - restriction: >= netstandard1.3
       System.Xml.XmlDocument (>= 4.3) - restriction: >= netstandard1.3
       System.Xml.XPath.XDocument (>= 4.3) - restriction: >= netstandard1.3
-    Microsoft.CodeAnalysis.CSharp (2.9) - restriction: >= netcoreapp2.1
+    Microsoft.CodeAnalysis.CSharp (2.9) - restriction: >= netcoreapp3.0
       Microsoft.CodeAnalysis.Common (2.9)
-    Microsoft.CodeAnalysis.Razor (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.CodeAnalysis.Razor (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Razor.Language (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.Common (>= 2.8) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.CSharp (>= 2.8) - restriction: || (>= net46) (>= netstandard2.0)
     Microsoft.CodeCoverage (15.9) - restriction: || (>= net45) (>= netcoreapp1.0)
-    Microsoft.CSharp (4.5) - restriction: >= netcoreapp2.1
-    Microsoft.DotNet.PlatformAbstractions (2.1) - restriction: >= netcoreapp2.1
+    Microsoft.CSharp (4.5) - restriction: >= netcoreapp3.0
+    Microsoft.DotNet.PlatformAbstractions (2.1) - restriction: >= netcoreapp3.0
       System.AppContext (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Collections (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.3)
       System.IO (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
@@ -650,7 +650,7 @@ NUGET
       System.Runtime.Extensions (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Runtime.InteropServices (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Runtime.InteropServices.RuntimeInformation (>= 4.0) - restriction: || (>= net45) (>= netstandard1.3)
-    Microsoft.EntityFrameworkCore (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
@@ -661,171 +661,171 @@ NUGET
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5.1) - restriction: >= netstandard2.0
       System.Interactive.Async (>= 3.1.1) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Abstractions (2.1.4) - restriction: >= netcoreapp2.1
-    Microsoft.EntityFrameworkCore.Analyzers (2.1.4) - restriction: >= netcoreapp2.1
-    Microsoft.EntityFrameworkCore.Design (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore.Abstractions (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.Analyzers (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.Design (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.CSharp (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.4) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.EntityFrameworkCore.InMemory (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore.InMemory (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.EntityFrameworkCore (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Relational (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore.Relational (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.EntityFrameworkCore (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.SqlServer (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore.SqlServer (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.4) - restriction: >= netstandard2.0
       System.Data.SqlClient (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Tools (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore.Tools (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.EntityFrameworkCore.Design (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.Abstractions (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Caching.Abstractions (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.Memory (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Caching.Memory (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.SqlServer (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Caching.SqlServer (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Data.SqlClient (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Binder (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.Binder (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.CommandLine (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.CommandLine (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.EnvironmentVariables (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.EnvironmentVariables (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.FileExtensions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.FileExtensions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Ini (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.Ini (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Json (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.Json (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.KeyPerFile (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.KeyPerFile (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.UserSecrets (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.UserSecrets (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Json (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Xml (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.Xml (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Security.Cryptography.Xml (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.DependencyInjection (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.DependencyInjection (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.DependencyInjection.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.DependencyInjection.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
     Microsoft.Extensions.DependencyModel (2.1) - restriction: >= netcoreapp1.0
       Microsoft.DotNet.PlatformAbstractions (>= 2.1) - restriction: || (>= net451) (>= netstandard1.3)
       Newtonsoft.Json (>= 9.0.1) - restriction: || (>= net451) (>= netstandard1.3)
       System.Diagnostics.Debug (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
       System.Dynamic.Runtime (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
       System.Linq (>= 4.1) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
-    Microsoft.Extensions.DiagnosticAdapter (2.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.DiagnosticAdapter (2.1) - restriction: >= netcoreapp3.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.FileProviders.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.FileProviders.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Composite (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.FileProviders.Composite (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Embedded (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.FileProviders.Embedded (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Physical (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.FileProviders.Physical (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileSystemGlobbing (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.Extensions.Hosting (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.FileSystemGlobbing (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Hosting (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Hosting.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Hosting.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Http (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Http (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Identity.Core (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Identity.Core (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Identity.Stores (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Identity.Stores (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Identity.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Localization (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Localization (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Localization.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.Extensions.Logging (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Localization.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.Extensions.Logging.Configuration (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Logging.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging.Configuration (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Console (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Logging.Console (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Debug (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Logging.Debug (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.EventSource (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Logging.EventSource (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.TraceSource (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Logging.TraceSource (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.ObjectPool (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.Extensions.Options (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.ObjectPool (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Options (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Options.ConfigurationExtensions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Options.ConfigurationExtensions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Primitives (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Primitives (2.1.1) - restriction: >= netcoreapp3.0
       System.Memory (>= 4.5.1) - restriction: >= netstandard2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.WebEncoders (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.WebEncoders (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.IdentityModel.JsonWebTokens (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.JsonWebTokens (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Logging (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Logging (5.3) - restriction: >= netcoreapp3.0
       System.Diagnostics.Tracing (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Globalization (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IO (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IO.FileSystem (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Protocols (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Protocols (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Logging (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Collections.Specialized (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Diagnostics.Contracts (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Net.Http (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Protocols.OpenIdConnect (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Protocols.OpenIdConnect (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Protocols (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Dynamic.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IdentityModel.Tokens.Jwt (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Protocols.WsFederation (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Protocols.WsFederation (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Protocols (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens.Saml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Xml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Xml.XmlDocument (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Tokens (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Tokens (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Logging (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Collections (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
@@ -841,12 +841,12 @@ NUGET
       System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Text.RegularExpressions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Threading (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Tokens.Saml (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Tokens.Saml (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Xml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Xml (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Xml (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.Net.Http.Headers (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Net.Http.Headers (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
     Microsoft.NET.Test.Sdk (15.9)
@@ -887,10 +887,10 @@ NUGET
     NETStandard.Library (2.0.3) - restriction: || (&& (< net35) (>= netstandard1.1) (< netstandard2.0)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= netstandard2.0)) (&& (< net452) (>= netstandard1.1)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (>= net45) (< netstandard1.3)) (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.4)) (>= net461) (>= netcoreapp2.0) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8) (< win8)) (&& (< netstandard1.0) (< portable-net45+win8) (>= portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard1.3) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= uap10.0)) (>= uap10.1) (>= wp8)
     Newtonsoft.Json (11.0.2) - restriction: || (>= net461) (>= netcoreapp1.0) (>= netstandard2.0) (>= uap10.0)
-    Newtonsoft.Json.Bson (1.0.1) - restriction: >= netcoreapp2.1
+    Newtonsoft.Json.Bson (1.0.1) - restriction: >= netcoreapp3.0
       NETStandard.Library (>= 1.6.1) - restriction: && (< net45) (>= netstandard1.3)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (>= net45) (>= netstandard1.3)
-    Remotion.Linq (2.2) - restriction: >= netcoreapp2.1
+    Remotion.Linq (2.2) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
       System.Diagnostics.Debug (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
       System.Linq (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
@@ -902,28 +902,28 @@ NUGET
       System.Runtime (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
       System.Runtime.Extensions (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
       System.Threading (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
-    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
+    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
     runtime.native.System (4.3.1) - restriction: >= netcoreapp1.0
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Data.SqlClient.sni (4.5) - restriction: >= netcoreapp2.1
+    runtime.native.System.Data.SqlClient.sni (4.5) - restriction: >= netcoreapp3.0
       runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (>= 4.4)
       runtime.win-x64.runtime.native.System.Data.SqlClient.sni (>= 4.4)
       runtime.win-x86.runtime.native.System.Data.SqlClient.sni (>= 4.4)
-    runtime.native.System.IO.Compression (4.3.2) - restriction: >= netcoreapp2.1
+    runtime.native.System.IO.Compression (4.3.2) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Net.Http (4.3.1) - restriction: >= netcoreapp2.1
+    runtime.native.System.Net.Http (4.3.1) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp2.1
+    runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.0
       runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (>= 4.3.1)
-    runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
+    runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
       runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
@@ -939,22 +939,22 @@ NUGET
       runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp2.1
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp2.1
-    runtime.win-x64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp2.1
-    runtime.win-x86.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp2.1
-    System.AppContext (4.3) - restriction: >= netcoreapp2.1
+    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.0
+    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
+    runtime.win-x64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
+    runtime.win-x86.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
+    System.AppContext (4.3) - restriction: >= netcoreapp3.0
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Buffers (4.5) - restriction: >= netcoreapp2.1
+    System.Buffers (4.5) - restriction: >= netcoreapp3.0
     System.Collections (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -970,15 +970,15 @@ NUGET
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
-    System.Collections.Immutable (1.5) - restriction: >= netcoreapp2.1
-    System.Collections.NonGeneric (4.3) - restriction: >= netcoreapp2.1
+    System.Collections.Immutable (1.5) - restriction: >= netcoreapp3.0
+    System.Collections.NonGeneric (4.3) - restriction: >= netcoreapp3.0
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Collections.Specialized (4.3) - restriction: >= netcoreapp2.1
+    System.Collections.Specialized (4.3) - restriction: >= netcoreapp3.0
       System.Collections.NonGeneric (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -986,7 +986,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.ComponentModel.Annotations (4.5) - restriction: >= netcoreapp2.1
+    System.ComponentModel.Annotations (4.5) - restriction: >= netcoreapp3.0
     System.ComponentModel.EventBasedAsync (4.3) - restriction: >= netcoreapp1.0
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -995,25 +995,25 @@ NUGET
     System.ComponentModel.Primitives (4.3) - restriction: >= uap10.0
     System.ComponentModel.TypeConverter (4.3) - restriction: || (>= netcoreapp1.0) (>= uap10.0)
       System.ComponentModel.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.5) (< win8)) (&& (>= net45) (< netstandard1.5)) (>= net462) (&& (< netstandard1.0) (>= win8)) (>= wp8) (>= wpa81)
-    System.Console (4.3.1) - restriction: >= netcoreapp2.1
+    System.Console (4.3.1) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1.2) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Data.SqlClient (4.5.1) - restriction: >= netcoreapp2.1
+    System.Data.SqlClient (4.5.1) - restriction: >= netcoreapp3.0
       Microsoft.Win32.Registry (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       runtime.native.System.Data.SqlClient.sni (>= 4.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net451) (>= netstandard1.3) (< netstandard2.0) (< win81) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       System.Security.Principal.Windows (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       System.Text.Encoding.CodePages (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
-    System.Diagnostics.Contracts (4.3) - restriction: >= netcoreapp2.1
+    System.Diagnostics.Contracts (4.3) - restriction: >= netcoreapp3.0
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
     System.Diagnostics.Debug (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (>= netstandard1.6)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Diagnostics.DiagnosticSource (4.5.1) - restriction: >= netcoreapp2.1
-    System.Diagnostics.FileVersionInfo (4.3) - restriction: >= netcoreapp2.1
+    System.Diagnostics.DiagnosticSource (4.5.1) - restriction: >= netcoreapp3.0
+    System.Diagnostics.FileVersionInfo (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1045,7 +1045,7 @@ NUGET
       System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.Thread (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.ThreadPool (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.StackTrace (4.3) - restriction: >= netcoreapp2.1
+    System.Diagnostics.StackTrace (4.3) - restriction: >= netcoreapp3.0
       System.IO.FileSystem (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection.Metadata (>= 1.4.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1057,7 +1057,7 @@ NUGET
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.Tools (4.3) - restriction: >= netcoreapp2.1
+    System.Diagnostics.Tools (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1071,11 +1071,11 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.Tracing (4.3) - restriction: >= netcoreapp2.1
+    System.Diagnostics.Tracing (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Dynamic.Runtime (4.3) - restriction: >= netcoreapp2.1
+    System.Dynamic.Runtime (4.3) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Linq (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1094,30 +1094,30 @@ NUGET
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Globalization.Calendars (4.3) - restriction: >= netcoreapp2.1
+    System.Globalization.Calendars (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Globalization.Extensions (4.3) - restriction: >= netcoreapp2.1
+    System.Globalization.Extensions (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.IdentityModel.Tokens.Jwt (5.3) - restriction: >= netcoreapp2.1
+    System.IdentityModel.Tokens.Jwt (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.JsonWebTokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    System.Interactive.Async (3.2) - restriction: >= netcoreapp2.1
+    System.Interactive.Async (3.2) - restriction: >= netcoreapp3.0
     System.IO (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.IO.Compression (4.3) - restriction: >= netcoreapp2.1
+    System.IO.Compression (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.IO.Compression (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1151,7 +1151,7 @@ NUGET
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.6) (< win8) (< wp8) (< wpa81))
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Linq.Expressions (4.3) - restriction: >= netcoreapp2.1
+    System.Linq.Expressions (4.3) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1169,7 +1169,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Linq.Queryable (4.3) - restriction: >= netcoreapp2.1
+    System.Linq.Queryable (4.3) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Linq (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -1178,8 +1178,8 @@ NUGET
       System.Reflection.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Memory (4.5.1) - restriction: >= netcoreapp2.1
-    System.Net.Http (4.3.4) - restriction: >= netcoreapp2.1
+    System.Memory (4.5.1) - restriction: >= netcoreapp3.0
+    System.Net.Http (4.3.4) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Net.Http (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1206,14 +1206,14 @@ NUGET
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-    System.Net.Primitives (4.3) - restriction: >= netcoreapp2.1
+    System.Net.Primitives (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       System.Runtime.Handles (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Net.WebSockets.WebSocketProtocol (4.5.2) - restriction: >= netcoreapp2.1
-    System.Numerics.Vectors (4.5) - restriction: >= netcoreapp2.1
-    System.ObjectModel (4.3) - restriction: >= netcoreapp2.1
+    System.Net.WebSockets.WebSocketProtocol (4.5.2) - restriction: >= netcoreapp3.0
+    System.Numerics.Vectors (4.5) - restriction: >= netcoreapp3.0
+    System.ObjectModel (4.3) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1251,7 +1251,7 @@ NUGET
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Reflection.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Reflection.Emit (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp2.1)
+    System.Reflection.Emit (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.0)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1286,7 +1286,7 @@ NUGET
     System.Runtime (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= net461) (< netstandard1.6)) (&& (< net45) (>= net461) (< netstandard2.0)) (&& (< net45) (>= net47)) (&& (>= net461) (>= netcoreapp1.1)) (>= netcoreapp1.0) (&& (>= netcoreapp1.1) (>= netstandard2.0))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Runtime.CompilerServices.Unsafe (4.5.2) - restriction: >= netcoreapp2.1
+    System.Runtime.CompilerServices.Unsafe (4.5.2) - restriction: >= netcoreapp3.0
     System.Runtime.Extensions (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
@@ -1307,7 +1307,7 @@ NUGET
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Runtime.Numerics (4.3) - restriction: >= netcoreapp2.1
+    System.Runtime.Numerics (4.3) - restriction: >= netcoreapp3.0
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
@@ -1319,17 +1319,17 @@ NUGET
     System.Runtime.Serialization.Primitives (4.3) - restriction: >= netcoreapp1.0
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Runtime.Serialization.Xml (4.3) - restriction: >= netcoreapp2.1
+    System.Runtime.Serialization.Xml (4.3) - restriction: >= netcoreapp3.0
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Private.DataContractSerialization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime.Serialization.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Xml.ReaderWriter (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Security.AccessControl (4.5) - restriction: >= netcoreapp2.1
+    System.Security.AccessControl (4.5) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: || (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0)
-    System.Security.Claims (4.3) - restriction: >= netcoreapp2.1
+    System.Security.Claims (4.3) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1337,7 +1337,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Security.Principal (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.Algorithms (4.3.1) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.Algorithms (4.3.1) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       runtime.native.System.Security.Cryptography.Apple (>= 4.3.1) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.2) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1352,8 +1352,8 @@ NUGET
       System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net463)
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net46) (< netstandard1.4)) (&& (>= net461) (< netstandard1.6)) (>= net463)
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Cryptography.Cng (4.5) - restriction: >= netcoreapp2.1
-    System.Security.Cryptography.Csp (4.3) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.Cng (4.5) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Csp (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1367,7 +1367,7 @@ NUGET
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.Encoding (4.3) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.Encoding (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1380,10 +1380,10 @@ NUGET
       System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.OpenSsl (4.5) - restriction: >= netcoreapp2.1
-    System.Security.Cryptography.Pkcs (4.5.1) - restriction: >= netcoreapp2.1
-      System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netcoreapp2.1
-    System.Security.Cryptography.Primitives (4.3) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.OpenSsl (4.5) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Pkcs (4.5.1) - restriction: >= netcoreapp3.0
+      System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Primitives (4.3) - restriction: >= netcoreapp3.0
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1391,7 +1391,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.X509Certificates (4.3.2) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.X509Certificates (4.3.2) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       runtime.native.System (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Net.Http (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1417,20 +1417,20 @@ NUGET
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Cryptography.Xml (4.5) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.Xml (4.5) - restriction: >= netcoreapp3.0
       System.Security.Cryptography.Pkcs (>= 4.5) - restriction: && (< net461) (>= netstandard2.0)
       System.Security.Permissions (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Security.Permissions (4.5) - restriction: >= netcoreapp2.1
+    System.Security.Permissions (4.5) - restriction: >= netcoreapp3.0
       System.Security.AccessControl (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Security.Principal (4.3) - restriction: >= netcoreapp2.1
+    System.Security.Principal (4.3) - restriction: >= netcoreapp3.0
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Principal.Windows (4.5.1) - restriction: >= netcoreapp2.1
+    System.Security.Principal.Windows (4.5.1) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
     System.Text.Encoding (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5)) (&& (< net45) (>= net461) (< netstandard1.5)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Text.Encoding.CodePages (4.5) - restriction: >= netcoreapp2.1
+    System.Text.Encoding.CodePages (4.5) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: || (&& (< net46) (>= netstandard2.0) (< xamarinios)) (>= net461) (>= netcoreapp2.0)
     System.Text.Encoding.Extensions (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
@@ -1438,7 +1438,7 @@ NUGET
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Text.Encodings.Web (4.5) - restriction: >= netcoreapp2.1
+    System.Text.Encodings.Web (4.5) - restriction: >= netcoreapp3.0
     System.Text.RegularExpressions (4.3) - restriction: || (>= net461) (>= netcoreapp1.0) (>= netstandard2.0)
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1449,13 +1449,13 @@ NUGET
     System.Threading (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Threading.Channels (4.5) - restriction: >= netcoreapp2.1
+    System.Threading.Channels (4.5) - restriction: >= netcoreapp3.0
     System.Threading.Tasks (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5)) (&& (< net45) (>= net461) (< netstandard1.5)) (&& (< net45) (>= net461) (>= netstandard1.6)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Threading.Tasks.Extensions (4.5.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp2.1)
-    System.Threading.Tasks.Parallel (4.3) - restriction: >= netcoreapp2.1
+    System.Threading.Tasks.Extensions (4.5.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.0)
+    System.Threading.Tasks.Parallel (4.3) - restriction: >= netcoreapp3.0
       System.Collections.Concurrent (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Tracing (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1469,7 +1469,7 @@ NUGET
     System.Threading.ThreadPool (4.3) - restriction: >= netcoreapp1.0
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Handles (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.ValueTuple (4.5) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.6) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.1)
+    System.ValueTuple (4.5) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.6) (>= netstandard2.0)) (>= net461) (>= netcoreapp3.0)
     System.Xml.ReaderWriter (4.3.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1538,7 +1538,7 @@ NUGET
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Xml.ReaderWriter (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Xml.XPath.XDocument (4.3) - restriction: >= netcoreapp2.1
+    System.Xml.XPath.XDocument (4.3) - restriction: >= netcoreapp3.0
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Linq (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)

--- a/src/content/Giraffe/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
+++ b/src/content/Giraffe/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>AppNamePlaceholder</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/content/Giraffe/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
+++ b/src/content/Giraffe/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>AppNamePlaceholder</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -9,8 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UsePaket)' == false OR '$(UsePaket)' == ''">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
-    <PackageReference Include="Giraffe" Version="3.4.*" />
+    <PackageReference Include="Giraffe" Version="4.0.*" />
     <PackageReference Include="TaskBuilder.fs" Version="2.1.*" />
   </ItemGroup>
 

--- a/src/content/Giraffe/src/AppNamePlaceholder/Program.fs
+++ b/src/content/Giraffe/src/AppNamePlaceholder/Program.fs
@@ -83,10 +83,10 @@ let configureCors (builder : CorsPolicyBuilder) =
            |> ignore
 
 let configureApp (app : IApplicationBuilder) =
-    let env = app.ApplicationServices.GetService<IHostingEnvironment>()
-    (match env.IsDevelopment() with
-    | true  -> app.UseDeveloperExceptionPage()
-    | false -> app.UseGiraffeErrorHandler errorHandler)
+    let env = app.ApplicationServices.GetService<IWebHostEnvironment>()
+    (match env.EnvironmentName with
+    | "Development" -> app.UseDeveloperExceptionPage()
+    | _ -> app.UseGiraffeErrorHandler(errorHandler))
         .UseHttpsRedirection()
         .UseCors(configureCors)
         .UseStaticFiles()

--- a/src/content/Giraffe/src/AppNamePlaceholder/paket.references
+++ b/src/content/Giraffe/src/AppNamePlaceholder/paket.references
@@ -1,2 +1,1 @@
-Microsoft.AspNetCore.App
 Giraffe

--- a/src/content/Giraffe/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
+++ b/src/content/Giraffe/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UsePaket)' == false OR '$(UsePaket)' == ''">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.*" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.*" />
     <PackageReference Include="xunit" Version="2.4.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.*" />
   </ItemGroup>

--- a/src/content/Giraffe/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
+++ b/src/content/Giraffe/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UsePaket)' == false OR '$(UsePaket)' == ''">

--- a/src/content/None/paket.dependencies
+++ b/src/content/None/paket.dependencies
@@ -1,7 +1,6 @@
 storage: none
 source https://api.nuget.org/v3/index.json
 
-nuget Microsoft.AspNetCore.App
 nuget Giraffe
 nuget Microsoft.NET.Test.Sdk
 nuget Microsoft.AspNetCore.TestHost

--- a/src/content/None/paket.lock
+++ b/src/content/None/paket.lock
@@ -15,10 +15,10 @@ NUGET
       System.Xml.XmlSerializer (>= 4.3) - restriction: || (>= net461) (>= netstandard2.0)
       TaskBuilder.fs (>= 2.1) - restriction: || (>= net461) (>= netstandard2.0)
       Utf8Json (>= 1.3.7) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNet.WebApi.Client (5.2.6) - restriction: >= netcoreapp2.1
+    Microsoft.AspNet.WebApi.Client (5.2.6) - restriction: >= netcoreapp3.0
       Newtonsoft.Json (>= 10.0.1) - restriction: && (< net45) (>= netstandard2.0)
       Newtonsoft.Json.Bson (>= 1.0.1) - restriction: && (< net45) (>= netstandard2.0)
-    Microsoft.AspNetCore (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Diagnostics (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.HostFiltering (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
@@ -35,158 +35,158 @@ NUGET
       Microsoft.Extensions.Logging.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Console (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Debug (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Antiforgery (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Antiforgery (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.App (2.1.5)
-      Microsoft.AspNet.WebApi.Client (>= 5.2.6 < 5.3) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Antiforgery (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Facebook (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Google (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.JwtBearer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.MicrosoftAccount (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.OpenIdConnect (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Twitter (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.WsFederation (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authorization (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authorization.Policy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.CookiePolicy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Cors (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.DataProtection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.DataProtection.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Diagnostics (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.HostFiltering (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http.Connections (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http.Connections.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http.Features (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.HttpOverrides (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.HttpsPolicy (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Identity (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Identity.EntityFrameworkCore (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Identity.UI (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.JsonPatch (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Localization.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.MiddlewareAnalysis (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Analyzers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Formatters.Xml (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Localization (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.NodeServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Owin (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Razor.Design (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Razor.Language (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Razor.Runtime (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.ResponseCaching (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.ResponseCompression (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Rewrite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.HttpSys (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.IISIntegration (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.Kestrel (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Session (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SignalR (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SignalR.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SignalR.Core (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SpaServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SpaServices.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.StaticFiles (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.WebSockets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.WebUtilities (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.CodeAnalysis.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.Design (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.InMemory (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.Relational (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.SqlServer (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.Tools (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Caching.Abstractions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Caching.Memory (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Caching.SqlServer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.Binder (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.CommandLine (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.Ini (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.Json (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.KeyPerFile (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.UserSecrets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.Xml (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.DependencyInjection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.DiagnosticAdapter (>= 2.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.FileProviders.Composite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Identity.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Identity.Stores (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Localization.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.Console (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.Debug (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.EventSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.TraceSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.ObjectPool (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Options (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Primitives (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.WebEncoders (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Net.Http.Headers (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      System.IO.Pipelines (>= 4.5.2) - restriction: >= netcoreapp2.1
+      Microsoft.AspNet.WebApi.Client (>= 5.2.6 < 5.3) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Antiforgery (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Facebook (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Google (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.JwtBearer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.MicrosoftAccount (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.OpenIdConnect (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Twitter (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.WsFederation (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authorization (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authorization.Policy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.CookiePolicy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Cors (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.DataProtection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.DataProtection.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Diagnostics (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.HostFiltering (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http.Connections (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http.Connections.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http.Features (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.HttpOverrides (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.HttpsPolicy (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Identity (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Identity.EntityFrameworkCore (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Identity.UI (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.JsonPatch (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Localization.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.MiddlewareAnalysis (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Analyzers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Formatters.Xml (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Localization (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.NodeServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Owin (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Razor.Design (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Razor.Language (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Razor.Runtime (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.ResponseCaching (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.ResponseCompression (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Rewrite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.HttpSys (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.IISIntegration (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.Kestrel (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Session (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SignalR (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SignalR.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SignalR.Core (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SpaServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SpaServices.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.StaticFiles (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.WebSockets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.WebUtilities (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.CodeAnalysis.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.Design (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.InMemory (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.Relational (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.SqlServer (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.Tools (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Caching.Abstractions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Caching.Memory (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Caching.SqlServer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.Binder (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.CommandLine (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.Ini (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.Json (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.KeyPerFile (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.UserSecrets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.Xml (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.DependencyInjection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.DiagnosticAdapter (>= 2.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.FileProviders.Composite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Identity.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Identity.Stores (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Localization.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.Console (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.Debug (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.EventSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.TraceSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.ObjectPool (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Options (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Primitives (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.WebEncoders (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Net.Http.Headers (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      System.IO.Pipelines (>= 4.5.2) - restriction: >= netcoreapp3.0
     Microsoft.AspNetCore.Authentication (2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
@@ -195,60 +195,60 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.WebEncoders (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Cookies (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Cookies (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Core (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Core (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Facebook (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Facebook (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Google (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Google (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.JwtBearer (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.JwtBearer (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.OpenIdConnect (>= 5.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.MicrosoftAccount (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.MicrosoftAccount (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.OAuth (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.OAuth (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.OpenIdConnect (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.OpenIdConnect (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.OpenIdConnect (>= 5.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Twitter (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Twitter (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.WsFederation (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.WsFederation (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.WsFederation (>= 5.2) - restriction: >= netstandard2.0
       System.IdentityModel.Tokens.Jwt (>= 5.2) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.Authorization (2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authorization.Policy (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authorization.Policy (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Authorization (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Connections.Abstractions (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Connections.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       System.IO.Pipelines (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.CookiePolicy (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.CookiePolicy (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cors (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Cors (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cryptography.Internal (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.Cryptography.KeyDerivation (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Cryptography.Internal (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Cryptography.KeyDerivation (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.DataProtection (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.DataProtection (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -258,8 +258,8 @@ NUGET
       Microsoft.Win32.Registry (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Cryptography.Xml (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.DataProtection.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.DataProtection.Extensions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.DataProtection.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.DataProtection.Extensions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.Diagnostics (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -272,11 +272,11 @@ NUGET
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
       System.Reflection.Metadata (>= 1.6) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Diagnostics.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Diagnostics.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HostFiltering (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.HostFiltering (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -299,21 +299,21 @@ NUGET
       Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Html.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Html.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Connections (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http.Connections (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authorization.Policy (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
@@ -321,58 +321,58 @@ NUGET
       Microsoft.AspNetCore.Routing (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebSockets (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Connections.Common (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http.Connections.Common (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Extensions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http.Extensions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Features (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http.Features (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HttpOverrides (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.HttpOverrides (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HttpsPolicy (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.HttpsPolicy (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Identity (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity.EntityFrameworkCore (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Identity.EntityFrameworkCore (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Identity (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Stores (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity.UI (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Identity.UI (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Identity (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.StaticFiles (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Stores (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.JsonPatch (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.JsonPatch (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.CSharp (>= 4.5) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Localization (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Localization (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Localization.Routing (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Localization.Routing (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.MiddlewareAnalysis (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.MiddlewareAnalysis (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3) - restriction: >= netstandard2.0
@@ -385,13 +385,13 @@ NUGET
       Microsoft.AspNetCore.Razor.Design (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Abstractions (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Analyzers (2.1.3) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.Mvc.ApiExplorer (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Analyzers (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.ApiExplorer (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Core (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Core (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Authorization.Policy (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -406,24 +406,24 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5.1) - restriction: >= netstandard2.0
       System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Cors (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Cors (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Cors (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.DataAnnotations (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.DataAnnotations (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Formatters.Json (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Formatters.Json (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.JsonPatch (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Formatters.Xml (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Formatters.Xml (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Localization (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Localization (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Razor (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Razor (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Razor.Runtime (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -431,22 +431,22 @@ NUGET
       Microsoft.CodeAnalysis.Razor (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.FileProviders.Composite (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNetCore.Mvc.Razor.Extensions (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Razor.Extensions (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Razor.Language (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.Razor (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
-    Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: || (>= net461) (>= netcoreapp2.0)
       Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.1) - restriction: || (>= net461) (>= netcoreapp2.0)
-    Microsoft.AspNetCore.Mvc.RazorPages (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.RazorPages (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.TagHelpers (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.TagHelpers (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Razor.Runtime (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.ViewFeatures (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.ViewFeatures (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Antiforgery (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -455,17 +455,17 @@ NUGET
       Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.WebEncoders (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json.Bson (>= 1.0.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.NodeServices (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.NodeServices (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Console (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Owin (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Owin (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Razor (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor.Design (2.1.2) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.Razor.Language (2.1.2) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.Razor.Runtime (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Razor.Design (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Razor.Language (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Razor.Runtime (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Razor (>= 2.1.2) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.ResponseCaching (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -474,33 +474,33 @@ NUGET
       Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCompression (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.ResponseCompression (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNetCore.Rewrite (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Rewrite (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Routing (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Routing (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Routing.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Routing.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.HttpSys (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.HttpSys (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Win32.Registry (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.IISIntegration (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.IISIntegration (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
@@ -514,12 +514,12 @@ NUGET
       System.Numerics.Vectors (>= 4.5) - restriction: >= netstandard2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5.2) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.Kestrel (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Core (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.Kestrel.Core (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
@@ -532,30 +532,30 @@ NUGET
       System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
       System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netstandard2.0
       System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Https (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.Kestrel.Https (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Session (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Session (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SignalR (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Connections (>= 1.0.4) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Core (>= 1.0.4) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Common (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SignalR.Common (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Core (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SignalR.Core (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authorization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Common (>= 1.0.4) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4) - restriction: >= netstandard2.0
@@ -563,19 +563,19 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Reflection.Emit (>= 4.3) - restriction: >= netstandard2.0
       System.Threading.Channels (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Protocols.Json (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SignalR.Protocols.Json (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.SignalR.Common (>= 1.0.4) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SpaServices (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SpaServices (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.NodeServices (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SpaServices.Extensions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SpaServices.Extensions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.SpaServices (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.StaticFiles (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebSockets (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.StaticFiles (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.StaticFiles (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -584,15 +584,15 @@ NUGET
     Microsoft.AspNetCore.TestHost (2.1.1)
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       System.IO.Pipelines (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.WebSockets (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.WebSockets (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Net.WebSockets.WebSocketProtocol (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.WebUtilities (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.WebUtilities (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.CodeAnalysis.Analyzers (2.6.2) - restriction: >= netcoreapp2.1
-    Microsoft.CodeAnalysis.Common (2.9) - restriction: >= netcoreapp2.1
+    Microsoft.CodeAnalysis.Analyzers (2.6.2) - restriction: >= netcoreapp3.0
+    Microsoft.CodeAnalysis.Common (2.9) - restriction: >= netcoreapp3.0
       Microsoft.CodeAnalysis.Analyzers (>= 2.6.1) - restriction: >= netstandard1.3
       System.AppContext (>= 4.3) - restriction: >= netstandard1.3
       System.Collections (>= 4.3) - restriction: >= netstandard1.3
@@ -633,15 +633,15 @@ NUGET
       System.Xml.XDocument (>= 4.3) - restriction: >= netstandard1.3
       System.Xml.XmlDocument (>= 4.3) - restriction: >= netstandard1.3
       System.Xml.XPath.XDocument (>= 4.3) - restriction: >= netstandard1.3
-    Microsoft.CodeAnalysis.CSharp (2.9) - restriction: >= netcoreapp2.1
+    Microsoft.CodeAnalysis.CSharp (2.9) - restriction: >= netcoreapp3.0
       Microsoft.CodeAnalysis.Common (2.9)
-    Microsoft.CodeAnalysis.Razor (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.CodeAnalysis.Razor (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Razor.Language (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.Common (>= 2.8) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.CSharp (>= 2.8) - restriction: || (>= net46) (>= netstandard2.0)
     Microsoft.CodeCoverage (15.9) - restriction: || (>= net45) (>= netcoreapp1.0)
-    Microsoft.CSharp (4.5) - restriction: >= netcoreapp2.1
-    Microsoft.DotNet.PlatformAbstractions (2.1) - restriction: >= netcoreapp2.1
+    Microsoft.CSharp (4.5) - restriction: >= netcoreapp3.0
+    Microsoft.DotNet.PlatformAbstractions (2.1) - restriction: >= netcoreapp3.0
       System.AppContext (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Collections (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.3)
       System.IO (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
@@ -650,7 +650,7 @@ NUGET
       System.Runtime.Extensions (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Runtime.InteropServices (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Runtime.InteropServices.RuntimeInformation (>= 4.0) - restriction: || (>= net45) (>= netstandard1.3)
-    Microsoft.EntityFrameworkCore (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
@@ -661,171 +661,171 @@ NUGET
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5.1) - restriction: >= netstandard2.0
       System.Interactive.Async (>= 3.1.1) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Abstractions (2.1.4) - restriction: >= netcoreapp2.1
-    Microsoft.EntityFrameworkCore.Analyzers (2.1.4) - restriction: >= netcoreapp2.1
-    Microsoft.EntityFrameworkCore.Design (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore.Abstractions (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.Analyzers (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.Design (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.CSharp (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.4) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.EntityFrameworkCore.InMemory (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore.InMemory (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.EntityFrameworkCore (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Relational (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore.Relational (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.EntityFrameworkCore (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.SqlServer (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore.SqlServer (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.4) - restriction: >= netstandard2.0
       System.Data.SqlClient (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Tools (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore.Tools (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.EntityFrameworkCore.Design (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.Abstractions (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Caching.Abstractions (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.Memory (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Caching.Memory (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.SqlServer (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Caching.SqlServer (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Data.SqlClient (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Binder (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.Binder (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.CommandLine (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.CommandLine (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.EnvironmentVariables (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.EnvironmentVariables (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.FileExtensions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.FileExtensions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Ini (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.Ini (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Json (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.Json (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.KeyPerFile (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.KeyPerFile (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.UserSecrets (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.UserSecrets (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Json (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Xml (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.Xml (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Security.Cryptography.Xml (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.DependencyInjection (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.DependencyInjection (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.DependencyInjection.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.DependencyInjection.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
     Microsoft.Extensions.DependencyModel (2.1) - restriction: >= netcoreapp1.0
       Microsoft.DotNet.PlatformAbstractions (>= 2.1) - restriction: || (>= net451) (>= netstandard1.3)
       Newtonsoft.Json (>= 9.0.1) - restriction: || (>= net451) (>= netstandard1.3)
       System.Diagnostics.Debug (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
       System.Dynamic.Runtime (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
       System.Linq (>= 4.1) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
-    Microsoft.Extensions.DiagnosticAdapter (2.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.DiagnosticAdapter (2.1) - restriction: >= netcoreapp3.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.FileProviders.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.FileProviders.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Composite (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.FileProviders.Composite (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Embedded (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.FileProviders.Embedded (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Physical (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.FileProviders.Physical (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileSystemGlobbing (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.Extensions.Hosting (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.FileSystemGlobbing (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Hosting (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Hosting.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Hosting.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Http (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Http (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Identity.Core (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Identity.Core (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Identity.Stores (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Identity.Stores (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Identity.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Localization (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Localization (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Localization.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.Extensions.Logging (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Localization.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.Extensions.Logging.Configuration (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Logging.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging.Configuration (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Console (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Logging.Console (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Debug (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Logging.Debug (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.EventSource (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Logging.EventSource (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.TraceSource (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Logging.TraceSource (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.ObjectPool (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.Extensions.Options (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.ObjectPool (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Options (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Options.ConfigurationExtensions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Options.ConfigurationExtensions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Primitives (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Primitives (2.1.1) - restriction: >= netcoreapp3.0
       System.Memory (>= 4.5.1) - restriction: >= netstandard2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.WebEncoders (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.WebEncoders (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.IdentityModel.JsonWebTokens (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.JsonWebTokens (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Logging (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Logging (5.3) - restriction: >= netcoreapp3.0
       System.Diagnostics.Tracing (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Globalization (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IO (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IO.FileSystem (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Protocols (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Protocols (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Logging (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Collections.Specialized (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Diagnostics.Contracts (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Net.Http (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Protocols.OpenIdConnect (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Protocols.OpenIdConnect (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Protocols (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Dynamic.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IdentityModel.Tokens.Jwt (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Protocols.WsFederation (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Protocols.WsFederation (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Protocols (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens.Saml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Xml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Xml.XmlDocument (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Tokens (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Tokens (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Logging (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Collections (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
@@ -841,12 +841,12 @@ NUGET
       System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Text.RegularExpressions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Threading (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Tokens.Saml (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Tokens.Saml (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Xml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Xml (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Xml (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.Net.Http.Headers (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Net.Http.Headers (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
     Microsoft.NET.Test.Sdk (15.9)
@@ -887,10 +887,10 @@ NUGET
     NETStandard.Library (2.0.3) - restriction: || (&& (< net35) (>= netstandard1.1) (< netstandard2.0)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= netstandard2.0)) (&& (< net452) (>= netstandard1.1)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (>= net45) (< netstandard1.3)) (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.4)) (>= net461) (>= netcoreapp2.0) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8) (< win8)) (&& (< netstandard1.0) (< portable-net45+win8) (>= portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard1.3) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= uap10.0)) (>= uap10.1) (>= wp8)
     Newtonsoft.Json (11.0.2) - restriction: || (>= net461) (>= netcoreapp1.0) (>= netstandard2.0) (>= uap10.0)
-    Newtonsoft.Json.Bson (1.0.1) - restriction: >= netcoreapp2.1
+    Newtonsoft.Json.Bson (1.0.1) - restriction: >= netcoreapp3.0
       NETStandard.Library (>= 1.6.1) - restriction: && (< net45) (>= netstandard1.3)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (>= net45) (>= netstandard1.3)
-    Remotion.Linq (2.2) - restriction: >= netcoreapp2.1
+    Remotion.Linq (2.2) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
       System.Diagnostics.Debug (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
       System.Linq (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
@@ -902,28 +902,28 @@ NUGET
       System.Runtime (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
       System.Runtime.Extensions (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
       System.Threading (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
-    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
+    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
     runtime.native.System (4.3.1) - restriction: >= netcoreapp1.0
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Data.SqlClient.sni (4.5) - restriction: >= netcoreapp2.1
+    runtime.native.System.Data.SqlClient.sni (4.5) - restriction: >= netcoreapp3.0
       runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (>= 4.4)
       runtime.win-x64.runtime.native.System.Data.SqlClient.sni (>= 4.4)
       runtime.win-x86.runtime.native.System.Data.SqlClient.sni (>= 4.4)
-    runtime.native.System.IO.Compression (4.3.2) - restriction: >= netcoreapp2.1
+    runtime.native.System.IO.Compression (4.3.2) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Net.Http (4.3.1) - restriction: >= netcoreapp2.1
+    runtime.native.System.Net.Http (4.3.1) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp2.1
+    runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.0
       runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (>= 4.3.1)
-    runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
+    runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
       runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
@@ -939,22 +939,22 @@ NUGET
       runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp2.1
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp2.1
-    runtime.win-x64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp2.1
-    runtime.win-x86.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp2.1
-    System.AppContext (4.3) - restriction: >= netcoreapp2.1
+    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.0
+    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
+    runtime.win-x64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
+    runtime.win-x86.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
+    System.AppContext (4.3) - restriction: >= netcoreapp3.0
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Buffers (4.5) - restriction: >= netcoreapp2.1
+    System.Buffers (4.5) - restriction: >= netcoreapp3.0
     System.Collections (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -970,15 +970,15 @@ NUGET
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
-    System.Collections.Immutable (1.5) - restriction: >= netcoreapp2.1
-    System.Collections.NonGeneric (4.3) - restriction: >= netcoreapp2.1
+    System.Collections.Immutable (1.5) - restriction: >= netcoreapp3.0
+    System.Collections.NonGeneric (4.3) - restriction: >= netcoreapp3.0
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Collections.Specialized (4.3) - restriction: >= netcoreapp2.1
+    System.Collections.Specialized (4.3) - restriction: >= netcoreapp3.0
       System.Collections.NonGeneric (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -986,7 +986,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.ComponentModel.Annotations (4.5) - restriction: >= netcoreapp2.1
+    System.ComponentModel.Annotations (4.5) - restriction: >= netcoreapp3.0
     System.ComponentModel.EventBasedAsync (4.3) - restriction: >= netcoreapp1.0
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -995,25 +995,25 @@ NUGET
     System.ComponentModel.Primitives (4.3) - restriction: >= uap10.0
     System.ComponentModel.TypeConverter (4.3) - restriction: || (>= netcoreapp1.0) (>= uap10.0)
       System.ComponentModel.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.5) (< win8)) (&& (>= net45) (< netstandard1.5)) (>= net462) (&& (< netstandard1.0) (>= win8)) (>= wp8) (>= wpa81)
-    System.Console (4.3.1) - restriction: >= netcoreapp2.1
+    System.Console (4.3.1) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1.2) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Data.SqlClient (4.5.1) - restriction: >= netcoreapp2.1
+    System.Data.SqlClient (4.5.1) - restriction: >= netcoreapp3.0
       Microsoft.Win32.Registry (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       runtime.native.System.Data.SqlClient.sni (>= 4.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net451) (>= netstandard1.3) (< netstandard2.0) (< win81) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       System.Security.Principal.Windows (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       System.Text.Encoding.CodePages (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
-    System.Diagnostics.Contracts (4.3) - restriction: >= netcoreapp2.1
+    System.Diagnostics.Contracts (4.3) - restriction: >= netcoreapp3.0
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
     System.Diagnostics.Debug (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (>= netstandard1.6)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Diagnostics.DiagnosticSource (4.5.1) - restriction: >= netcoreapp2.1
-    System.Diagnostics.FileVersionInfo (4.3) - restriction: >= netcoreapp2.1
+    System.Diagnostics.DiagnosticSource (4.5.1) - restriction: >= netcoreapp3.0
+    System.Diagnostics.FileVersionInfo (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1045,7 +1045,7 @@ NUGET
       System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.Thread (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.ThreadPool (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.StackTrace (4.3) - restriction: >= netcoreapp2.1
+    System.Diagnostics.StackTrace (4.3) - restriction: >= netcoreapp3.0
       System.IO.FileSystem (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection.Metadata (>= 1.4.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1057,7 +1057,7 @@ NUGET
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.Tools (4.3) - restriction: >= netcoreapp2.1
+    System.Diagnostics.Tools (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1071,11 +1071,11 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.Tracing (4.3) - restriction: >= netcoreapp2.1
+    System.Diagnostics.Tracing (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Dynamic.Runtime (4.3) - restriction: >= netcoreapp2.1
+    System.Dynamic.Runtime (4.3) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Linq (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1094,30 +1094,30 @@ NUGET
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Globalization.Calendars (4.3) - restriction: >= netcoreapp2.1
+    System.Globalization.Calendars (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Globalization.Extensions (4.3) - restriction: >= netcoreapp2.1
+    System.Globalization.Extensions (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.IdentityModel.Tokens.Jwt (5.3) - restriction: >= netcoreapp2.1
+    System.IdentityModel.Tokens.Jwt (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.JsonWebTokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    System.Interactive.Async (3.2) - restriction: >= netcoreapp2.1
+    System.Interactive.Async (3.2) - restriction: >= netcoreapp3.0
     System.IO (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.IO.Compression (4.3) - restriction: >= netcoreapp2.1
+    System.IO.Compression (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.IO.Compression (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1151,7 +1151,7 @@ NUGET
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.6) (< win8) (< wp8) (< wpa81))
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Linq.Expressions (4.3) - restriction: >= netcoreapp2.1
+    System.Linq.Expressions (4.3) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1169,7 +1169,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Linq.Queryable (4.3) - restriction: >= netcoreapp2.1
+    System.Linq.Queryable (4.3) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Linq (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -1178,8 +1178,8 @@ NUGET
       System.Reflection.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Memory (4.5.1) - restriction: >= netcoreapp2.1
-    System.Net.Http (4.3.4) - restriction: >= netcoreapp2.1
+    System.Memory (4.5.1) - restriction: >= netcoreapp3.0
+    System.Net.Http (4.3.4) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Net.Http (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1206,14 +1206,14 @@ NUGET
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-    System.Net.Primitives (4.3) - restriction: >= netcoreapp2.1
+    System.Net.Primitives (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       System.Runtime.Handles (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Net.WebSockets.WebSocketProtocol (4.5.2) - restriction: >= netcoreapp2.1
-    System.Numerics.Vectors (4.5) - restriction: >= netcoreapp2.1
-    System.ObjectModel (4.3) - restriction: >= netcoreapp2.1
+    System.Net.WebSockets.WebSocketProtocol (4.5.2) - restriction: >= netcoreapp3.0
+    System.Numerics.Vectors (4.5) - restriction: >= netcoreapp3.0
+    System.ObjectModel (4.3) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1251,7 +1251,7 @@ NUGET
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Reflection.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Reflection.Emit (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp2.1)
+    System.Reflection.Emit (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.0)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1286,7 +1286,7 @@ NUGET
     System.Runtime (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= net461) (< netstandard1.6)) (&& (< net45) (>= net461) (< netstandard2.0)) (&& (< net45) (>= net47)) (&& (>= net461) (>= netcoreapp1.1)) (>= netcoreapp1.0) (&& (>= netcoreapp1.1) (>= netstandard2.0))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Runtime.CompilerServices.Unsafe (4.5.2) - restriction: >= netcoreapp2.1
+    System.Runtime.CompilerServices.Unsafe (4.5.2) - restriction: >= netcoreapp3.0
     System.Runtime.Extensions (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
@@ -1307,7 +1307,7 @@ NUGET
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Runtime.Numerics (4.3) - restriction: >= netcoreapp2.1
+    System.Runtime.Numerics (4.3) - restriction: >= netcoreapp3.0
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
@@ -1319,17 +1319,17 @@ NUGET
     System.Runtime.Serialization.Primitives (4.3) - restriction: >= netcoreapp1.0
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Runtime.Serialization.Xml (4.3) - restriction: >= netcoreapp2.1
+    System.Runtime.Serialization.Xml (4.3) - restriction: >= netcoreapp3.0
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Private.DataContractSerialization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime.Serialization.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Xml.ReaderWriter (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Security.AccessControl (4.5) - restriction: >= netcoreapp2.1
+    System.Security.AccessControl (4.5) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: || (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0)
-    System.Security.Claims (4.3) - restriction: >= netcoreapp2.1
+    System.Security.Claims (4.3) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1337,7 +1337,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Security.Principal (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.Algorithms (4.3.1) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.Algorithms (4.3.1) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       runtime.native.System.Security.Cryptography.Apple (>= 4.3.1) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.2) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1352,8 +1352,8 @@ NUGET
       System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net463)
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net46) (< netstandard1.4)) (&& (>= net461) (< netstandard1.6)) (>= net463)
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Cryptography.Cng (4.5) - restriction: >= netcoreapp2.1
-    System.Security.Cryptography.Csp (4.3) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.Cng (4.5) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Csp (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1367,7 +1367,7 @@ NUGET
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.Encoding (4.3) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.Encoding (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1380,10 +1380,10 @@ NUGET
       System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.OpenSsl (4.5) - restriction: >= netcoreapp2.1
-    System.Security.Cryptography.Pkcs (4.5.1) - restriction: >= netcoreapp2.1
-      System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netcoreapp2.1
-    System.Security.Cryptography.Primitives (4.3) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.OpenSsl (4.5) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Pkcs (4.5.1) - restriction: >= netcoreapp3.0
+      System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Primitives (4.3) - restriction: >= netcoreapp3.0
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1391,7 +1391,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.X509Certificates (4.3.2) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.X509Certificates (4.3.2) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       runtime.native.System (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Net.Http (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1417,20 +1417,20 @@ NUGET
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Cryptography.Xml (4.5) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.Xml (4.5) - restriction: >= netcoreapp3.0
       System.Security.Cryptography.Pkcs (>= 4.5) - restriction: && (< net461) (>= netstandard2.0)
       System.Security.Permissions (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Security.Permissions (4.5) - restriction: >= netcoreapp2.1
+    System.Security.Permissions (4.5) - restriction: >= netcoreapp3.0
       System.Security.AccessControl (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Security.Principal (4.3) - restriction: >= netcoreapp2.1
+    System.Security.Principal (4.3) - restriction: >= netcoreapp3.0
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Principal.Windows (4.5.1) - restriction: >= netcoreapp2.1
+    System.Security.Principal.Windows (4.5.1) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
     System.Text.Encoding (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5)) (&& (< net45) (>= net461) (< netstandard1.5)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Text.Encoding.CodePages (4.5) - restriction: >= netcoreapp2.1
+    System.Text.Encoding.CodePages (4.5) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: || (&& (< net46) (>= netstandard2.0) (< xamarinios)) (>= net461) (>= netcoreapp2.0)
     System.Text.Encoding.Extensions (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
@@ -1438,7 +1438,7 @@ NUGET
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Text.Encodings.Web (4.5) - restriction: >= netcoreapp2.1
+    System.Text.Encodings.Web (4.5) - restriction: >= netcoreapp3.0
     System.Text.RegularExpressions (4.3) - restriction: || (>= net461) (>= netcoreapp1.0) (>= netstandard2.0)
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1449,13 +1449,13 @@ NUGET
     System.Threading (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Threading.Channels (4.5) - restriction: >= netcoreapp2.1
+    System.Threading.Channels (4.5) - restriction: >= netcoreapp3.0
     System.Threading.Tasks (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5)) (&& (< net45) (>= net461) (< netstandard1.5)) (&& (< net45) (>= net461) (>= netstandard1.6)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Threading.Tasks.Extensions (4.5.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp2.1)
-    System.Threading.Tasks.Parallel (4.3) - restriction: >= netcoreapp2.1
+    System.Threading.Tasks.Extensions (4.5.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.0)
+    System.Threading.Tasks.Parallel (4.3) - restriction: >= netcoreapp3.0
       System.Collections.Concurrent (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Tracing (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1469,7 +1469,7 @@ NUGET
     System.Threading.ThreadPool (4.3) - restriction: >= netcoreapp1.0
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Handles (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.ValueTuple (4.5) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.6) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.1)
+    System.ValueTuple (4.5) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.6) (>= netstandard2.0)) (>= net461) (>= netcoreapp3.0)
     System.Xml.ReaderWriter (4.3.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1538,7 +1538,7 @@ NUGET
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Xml.ReaderWriter (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Xml.XPath.XDocument (4.3) - restriction: >= netcoreapp2.1
+    System.Xml.XPath.XDocument (4.3) - restriction: >= netcoreapp3.0
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Linq (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)

--- a/src/content/None/paket.lock
+++ b/src/content/None/paket.lock
@@ -1,1139 +1,197 @@
 STORAGE: NONE
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    FSharp.Core (4.5.2) - restriction: || (>= net461) (>= netstandard2.0)
-    Giraffe (3.4)
-      FSharp.Core (>= 4.5.2) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Authorization (>= 2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Diagnostics (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.ResponseCaching (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Newtonsoft.Json (>= 11.0.2) - restriction: || (>= net461) (>= netstandard2.0)
-      System.Text.RegularExpressions (>= 4.3) - restriction: || (>= net461) (>= netstandard2.0)
+    FSharp.Core (4.7) - restriction: || (>= net461) (>= netstandard2.0)
+    Giraffe (4.0.1)
+      FSharp.Core (>= 4.7) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.AspNetCore.Authentication (>= 2.2) - restriction: || (>= net461) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.AspNetCore.Authorization (>= 2.2) - restriction: || (>= net461) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.AspNetCore.Diagnostics (>= 2.2) - restriction: || (>= net461) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2) - restriction: || (>= net461) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.AspNetCore.ResponseCaching (>= 2.2) - restriction: || (>= net461) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.IO.RecyclableMemoryStream (>= 1.2.2) - restriction: || (>= net461) (>= netstandard2.0)
+      Newtonsoft.Json (>= 12.0.2) - restriction: || (>= net461) (>= netstandard2.0)
+      System.Text.RegularExpressions (>= 4.3.1) - restriction: || (>= net461) (>= netstandard2.0)
       System.ValueTuple (>= 4.4) - restriction: >= net461
+      System.ValueTuple (>= 4.5) - restriction: || (&& (< net461) (>= netstandard2.0)) (>= netcoreapp3.0)
       System.Xml.XmlSerializer (>= 4.3) - restriction: || (>= net461) (>= netstandard2.0)
       TaskBuilder.fs (>= 2.1) - restriction: || (>= net461) (>= netstandard2.0)
       Utf8Json (>= 1.3.7) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNet.WebApi.Client (5.2.6) - restriction: >= netcoreapp3.0
-      Newtonsoft.Json (>= 10.0.1) - restriction: && (< net45) (>= netstandard2.0)
-      Newtonsoft.Json.Bson (>= 1.0.1) - restriction: && (< net45) (>= netstandard2.0)
-    Microsoft.AspNetCore (2.1.4) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Diagnostics (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.HostFiltering (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Routing (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.IISIntegration (>= 2.1.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.CommandLine (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Json (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.UserSecrets (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Console (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Debug (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Antiforgery (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.App (2.1.5)
-      Microsoft.AspNet.WebApi.Client (>= 5.2.6 < 5.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Antiforgery (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Facebook (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Google (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.JwtBearer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.MicrosoftAccount (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.OpenIdConnect (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Twitter (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.WsFederation (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authorization (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authorization.Policy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.CookiePolicy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Cors (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.DataProtection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.DataProtection.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Diagnostics (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.HostFiltering (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Connections (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Connections.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Features (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.HttpOverrides (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.HttpsPolicy (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Identity (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Identity.EntityFrameworkCore (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Identity.UI (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.JsonPatch (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Localization.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.MiddlewareAnalysis (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Analyzers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Formatters.Xml (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Localization (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.NodeServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Owin (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Razor.Design (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Razor.Language (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Razor.Runtime (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.ResponseCaching (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.ResponseCompression (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Rewrite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.HttpSys (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.IISIntegration (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.Kestrel (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Session (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SignalR (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SignalR.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SignalR.Core (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SpaServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SpaServices.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.StaticFiles (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.WebSockets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.WebUtilities (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.CodeAnalysis.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Design (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.InMemory (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Relational (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.SqlServer (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Tools (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Caching.Abstractions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Caching.Memory (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Caching.SqlServer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Binder (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.CommandLine (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Ini (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Json (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.KeyPerFile (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.UserSecrets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Xml (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.DependencyInjection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.DiagnosticAdapter (>= 2.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileProviders.Composite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Identity.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Identity.Stores (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Localization.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.Console (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.Debug (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.EventSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.TraceSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.ObjectPool (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Options (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Primitives (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.WebEncoders (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Net.Http.Headers (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      System.IO.Pipelines (>= 4.5.2) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Authentication (2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.WebEncoders (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Cookies (2.1.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Core (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Facebook (2.1.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Google (2.1.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.JwtBearer (2.1.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
-      Microsoft.IdentityModel.Protocols.OpenIdConnect (>= 5.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.MicrosoftAccount (2.1.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.OAuth (2.1.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
-      Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.OpenIdConnect (2.1.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-      Microsoft.IdentityModel.Protocols.OpenIdConnect (>= 5.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Twitter (2.1.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.WsFederation (2.1.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
-      Microsoft.IdentityModel.Protocols.WsFederation (>= 5.2) - restriction: >= netstandard2.0
-      System.IdentityModel.Tokens.Jwt (>= 5.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authorization (2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authorization.Policy (2.1.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Authorization (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Connections.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
-      System.IO.Pipelines (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.CookiePolicy (2.1.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cors (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cryptography.Internal (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Cryptography.KeyDerivation (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.DataProtection (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Win32.Registry (>= 4.5) - restriction: >= netstandard2.0
-      System.Security.Cryptography.Xml (>= 4.5) - restriction: >= netstandard2.0
-      System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.DataProtection.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.DataProtection.Extensions (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Diagnostics (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Authentication (2.2) - restriction: || (>= net461) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.AspNetCore.Authentication.Core (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.DataProtection (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.Extensions.WebEncoders (>= 2.2) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Authentication.Abstractions (2.2) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Authentication.Core (2.2) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Authorization (3.1) - restriction: || (>= net461) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.AspNetCore.Metadata (>= 3.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 3.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 3.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Cryptography.Internal (3.1) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+    Microsoft.AspNetCore.DataProtection (3.1) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.AspNetCore.Cryptography.Internal (>= 3.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.DataProtection.Abstractions (>= 3.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 3.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Hosting.Abstractions (>= 3.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 3.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 3.1) - restriction: >= netstandard2.0
+      Microsoft.Win32.Registry (>= 4.7) - restriction: >= netstandard2.0
+      System.Security.Cryptography.Xml (>= 4.7) - restriction: >= netstandard2.0
+      System.Security.Principal.Windows (>= 4.7) - restriction: && (< netcoreapp3.1) (>= netstandard2.0)
+    Microsoft.AspNetCore.DataProtection.Abstractions (3.1) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+    Microsoft.AspNetCore.Diagnostics (2.2) - restriction: || (>= net461) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.WebUtilities (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.Extensions.FileProviders.Physical (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
       System.Reflection.Metadata (>= 1.6) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Diagnostics.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.EntityFrameworkCore.Relational (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HostFiltering (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Hosting (2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-      System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
-      System.Reflection.Metadata (>= 1.6) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Hosting.Abstractions (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Html.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Diagnostics.Abstractions (2.2) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+    Microsoft.AspNetCore.Hosting.Abstractions (2.2) - restriction: || (>= net461) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Hosting.Abstractions (>= 2.2) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.2) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.AspNetCore.Http.Features (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.2) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Http (2.2.2) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.WebUtilities (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.Extensions.ObjectPool (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.Net.Http.Headers (>= 2.2) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Http.Abstractions (2.2) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.AspNetCore.Http.Features (>= 2.2) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Http.Extensions (2.2) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.Extensions.FileProviders.Abstractions (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.Net.Http.Headers (>= 2.2) - restriction: >= netstandard2.0
+      System.Buffers (>= 4.5) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Http.Features (3.1) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.Extensions.Primitives (>= 3.1) - restriction: >= netstandard2.0
+      System.IO.Pipelines (>= 4.7) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Metadata (3.1) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+    Microsoft.AspNetCore.ResponseCaching (2.2) - restriction: || (>= net461) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.AspNetCore.Http (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Caching.Memory (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.2) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.Extensions.Primitives (>= 2.2) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.TestHost (3.1)
+      System.IO.Pipelines (>= 4.7) - restriction: >= netcoreapp3.1
+    Microsoft.AspNetCore.WebUtilities (2.2) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.Net.Http.Headers (>= 2.2) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Connections (1.0.4) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authorization.Policy (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Connections.Common (>= 1.0.4) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Routing (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.WebSockets (>= 2.1.1) - restriction: >= netstandard2.0
-      Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Connections.Common (1.0.4) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
-      Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
+    Microsoft.Bcl.AsyncInterfaces (1.1) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      System.Threading.Tasks.Extensions (>= 4.5.2) - restriction: || (>= net461) (&& (< netcoreapp2.1) (>= netstandard2.0)) (>= netstandard2.1)
+    Microsoft.CodeCoverage (16.4) - restriction: || (>= net45) (>= netcoreapp2.1)
+    Microsoft.Extensions.Caching.Abstractions (3.1) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.Extensions.Primitives (>= 3.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Caching.Memory (3.1) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.Extensions.Caching.Abstractions (>= 3.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 3.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 3.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 3.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Configuration.Abstractions (3.1) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.Extensions.Primitives (>= 3.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.DependencyInjection.Abstractions (3.1) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+    Microsoft.Extensions.FileProviders.Abstractions (3.1) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.Extensions.Primitives (>= 3.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.FileProviders.Physical (3.1) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.Extensions.FileProviders.Abstractions (>= 3.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.FileSystemGlobbing (>= 3.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.FileSystemGlobbing (3.1) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+    Microsoft.Extensions.Hosting.Abstractions (3.1) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.Bcl.AsyncInterfaces (>= 1.1) - restriction: && (< netcoreapp3.1) (>= netstandard2.0)
+      Microsoft.Extensions.Configuration.Abstractions (>= 3.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 3.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.FileProviders.Abstractions (>= 3.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 3.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Logging.Abstractions (3.1) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+    Microsoft.Extensions.ObjectPool (3.1) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+    Microsoft.Extensions.Options (3.1) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 3.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Primitives (>= 3.1) - restriction: >= netstandard2.0
+      System.ComponentModel.Annotations (>= 4.7) - restriction: && (< netcoreapp3.1) (>= netstandard2.0)
+    Microsoft.Extensions.Primitives (3.1) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      System.Memory (>= 4.5.2) - restriction: && (< netcoreapp3.1) (>= netstandard2.0)
+      System.Runtime.CompilerServices.Unsafe (>= 4.7) - restriction: && (< netcoreapp3.1) (>= netstandard2.0)
+    Microsoft.Extensions.WebEncoders (3.1) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 3.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 3.1) - restriction: >= netstandard2.0
+      System.Text.Encodings.Web (>= 4.7) - restriction: && (< netcoreapp3.1) (>= netstandard2.0)
+    Microsoft.IO.RecyclableMemoryStream (1.3) - restriction: || (>= net461) (>= netstandard2.0)
+      NETStandard.Library (>= 1.6.1) - restriction: && (< net40) (< netcoreapp2.1) (>= netstandard1.4) (< netstandard2.1)
+    Microsoft.Net.Http.Headers (2.2.8) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.Extensions.Primitives (>= 2.2) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Extensions (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
-      System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Features (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HttpOverrides (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HttpsPolicy (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Identity.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity.EntityFrameworkCore (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Identity (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.EntityFrameworkCore.Relational (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Identity.Stores (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity.UI (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Identity (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.StaticFiles (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Identity.Stores (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.JsonPatch (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.CSharp (>= 4.5) - restriction: >= netstandard2.0
-      Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Localization (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Localization.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Localization.Routing (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Localization (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.MiddlewareAnalysis (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Localization (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Razor.Design (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Analyzers (2.1.3) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Mvc.ApiExplorer (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Core (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Authorization.Policy (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Routing (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyModel (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      System.Diagnostics.DiagnosticSource (>= 4.5.1) - restriction: >= netstandard2.0
-      System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Cors (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Cors (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.DataAnnotations (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Localization (>= 2.1.1) - restriction: >= netstandard2.0
-      System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Formatters.Json (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.JsonPatch (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Formatters.Xml (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Localization (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Localization (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Localization (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Razor (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Razor.Runtime (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.CodeAnalysis.CSharp (>= 2.8) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.CodeAnalysis.Razor (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.FileProviders.Composite (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNetCore.Mvc.Razor.Extensions (2.1.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Razor.Language (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
-      Microsoft.CodeAnalysis.Razor (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
-    Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: || (>= net461) (>= netcoreapp2.0)
-      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.1) - restriction: || (>= net461) (>= netcoreapp2.0)
-    Microsoft.AspNetCore.Mvc.RazorPages (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.TagHelpers (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Razor.Runtime (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.ViewFeatures (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Antiforgery (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.Extensions.WebEncoders (>= 2.1.1) - restriction: >= netstandard2.0
-      Newtonsoft.Json.Bson (>= 1.0.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.NodeServices (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Console (>= 2.1.1) - restriction: >= netstandard2.0
-      Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Owin (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor (2.1.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor.Design (2.1.2) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Razor.Language (2.1.2) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Razor.Runtime (2.1.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Razor (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCaching (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCompression (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNetCore.Rewrite (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Routing (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Routing.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.HttpSys (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Win32.Registry (>= 4.5) - restriction: >= netstandard2.0
-      System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.IISIntegration (2.1.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.HttpOverrides (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-      System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-      System.IO.Pipelines (>= 4.5.2) - restriction: >= netstandard2.0
-      System.Memory (>= 4.5.1) - restriction: >= netstandard2.0
-      System.Numerics.Vectors (>= 4.5) - restriction: >= netstandard2.0
-      System.Runtime.CompilerServices.Unsafe (>= 4.5.2) - restriction: >= netstandard2.0
-      System.Security.Principal.Windows (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Core (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
-      System.Memory (>= 4.5.1) - restriction: >= netstandard2.0
-      System.Numerics.Vectors (>= 4.5) - restriction: >= netstandard2.0
-      System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
-      System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netstandard2.0
-      System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Https (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Session (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Caching.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR (1.0.4) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Connections (>= 1.0.4) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.SignalR.Core (>= 1.0.4) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Common (1.0.4) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-      Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-      System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Core (1.0.4) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authorization (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.SignalR.Common (>= 1.0.4) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      System.Reflection.Emit (>= 4.3) - restriction: >= netstandard2.0
-      System.Threading.Channels (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Protocols.Json (1.0.4) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SignalR.Common (>= 1.0.4) - restriction: >= netstandard2.0
-      Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SpaServices (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.NodeServices (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SpaServices.Extensions (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SpaServices (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.StaticFiles (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.WebSockets (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.StaticFiles (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.WebEncoders (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.TestHost (2.1.1)
-      Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
-      System.IO.Pipelines (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.WebSockets (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-      System.Net.WebSockets.WebSocketProtocol (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.WebUtilities (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
-      System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.CodeAnalysis.Analyzers (2.6.2) - restriction: >= netcoreapp3.0
-    Microsoft.CodeAnalysis.Common (2.9) - restriction: >= netcoreapp3.0
-      Microsoft.CodeAnalysis.Analyzers (>= 2.6.1) - restriction: >= netstandard1.3
-      System.AppContext (>= 4.3) - restriction: >= netstandard1.3
-      System.Collections (>= 4.3) - restriction: >= netstandard1.3
-      System.Collections.Concurrent (>= 4.3) - restriction: >= netstandard1.3
-      System.Collections.Immutable (>= 1.5) - restriction: >= netstandard1.3
-      System.Console (>= 4.3) - restriction: >= netstandard1.3
-      System.Diagnostics.Debug (>= 4.3) - restriction: >= netstandard1.3
-      System.Diagnostics.FileVersionInfo (>= 4.3) - restriction: >= netstandard1.3
-      System.Diagnostics.StackTrace (>= 4.3) - restriction: >= netstandard1.3
-      System.Diagnostics.Tools (>= 4.3) - restriction: >= netstandard1.3
-      System.Dynamic.Runtime (>= 4.3) - restriction: >= netstandard1.3
-      System.Globalization (>= 4.3) - restriction: >= netstandard1.3
-      System.IO.Compression (>= 4.3) - restriction: >= netstandard1.3
-      System.IO.FileSystem (>= 4.3) - restriction: >= netstandard1.3
-      System.IO.FileSystem.Primitives (>= 4.3) - restriction: >= netstandard1.3
-      System.Linq (>= 4.3) - restriction: >= netstandard1.3
-      System.Linq.Expressions (>= 4.3) - restriction: >= netstandard1.3
-      System.Reflection (>= 4.3) - restriction: >= netstandard1.3
-      System.Reflection.Metadata (>= 1.6) - restriction: >= netstandard1.3
-      System.Resources.ResourceManager (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime.Extensions (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime.InteropServices (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime.Numerics (>= 4.3) - restriction: >= netstandard1.3
-      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: >= netstandard1.3
-      System.Security.Cryptography.Encoding (>= 4.3) - restriction: >= netstandard1.3
-      System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: >= netstandard1.3
-      System.Text.Encoding (>= 4.3) - restriction: >= netstandard1.3
-      System.Text.Encoding.CodePages (>= 4.3) - restriction: >= netstandard1.3
-      System.Text.Encoding.Extensions (>= 4.3) - restriction: >= netstandard1.3
-      System.Threading (>= 4.3) - restriction: >= netstandard1.3
-      System.Threading.Tasks (>= 4.3) - restriction: >= netstandard1.3
-      System.Threading.Tasks.Extensions (>= 4.3) - restriction: >= netstandard1.3
-      System.Threading.Tasks.Parallel (>= 4.3) - restriction: >= netstandard1.3
-      System.Threading.Thread (>= 4.3) - restriction: >= netstandard1.3
-      System.ValueTuple (>= 4.3) - restriction: >= netstandard1.3
-      System.Xml.ReaderWriter (>= 4.3) - restriction: >= netstandard1.3
-      System.Xml.XDocument (>= 4.3) - restriction: >= netstandard1.3
-      System.Xml.XmlDocument (>= 4.3) - restriction: >= netstandard1.3
-      System.Xml.XPath.XDocument (>= 4.3) - restriction: >= netstandard1.3
-    Microsoft.CodeAnalysis.CSharp (2.9) - restriction: >= netcoreapp3.0
-      Microsoft.CodeAnalysis.Common (2.9)
-    Microsoft.CodeAnalysis.Razor (2.1.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Razor.Language (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
-      Microsoft.CodeAnalysis.Common (>= 2.8) - restriction: || (>= net46) (>= netstandard2.0)
-      Microsoft.CodeAnalysis.CSharp (>= 2.8) - restriction: || (>= net46) (>= netstandard2.0)
-    Microsoft.CodeCoverage (15.9) - restriction: || (>= net45) (>= netcoreapp1.0)
-    Microsoft.CSharp (4.5) - restriction: >= netcoreapp3.0
-    Microsoft.DotNet.PlatformAbstractions (2.1) - restriction: >= netcoreapp3.0
-      System.AppContext (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
-      System.Collections (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.3)
-      System.IO (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
-      System.IO.FileSystem (>= 4.0.1) - restriction: && (< net45) (>= netstandard1.3)
-      System.Reflection.TypeExtensions (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
-      System.Runtime.Extensions (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
-      System.Runtime.InteropServices (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
-      System.Runtime.InteropServices.RuntimeInformation (>= 4.0) - restriction: || (>= net45) (>= netstandard1.3)
-    Microsoft.EntityFrameworkCore (2.1.4) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4) - restriction: >= netstandard2.0
-      Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-      Remotion.Linq (>= 2.2) - restriction: >= netstandard2.0
-      System.Collections.Immutable (>= 1.5) - restriction: >= netstandard2.0
-      System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-      System.Diagnostics.DiagnosticSource (>= 4.5.1) - restriction: >= netstandard2.0
-      System.Interactive.Async (>= 3.1.1) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Abstractions (2.1.4) - restriction: >= netcoreapp3.0
-    Microsoft.EntityFrameworkCore.Analyzers (2.1.4) - restriction: >= netcoreapp3.0
-    Microsoft.EntityFrameworkCore.Design (2.1.4) - restriction: >= netcoreapp3.0
-      Microsoft.CSharp (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.EntityFrameworkCore.Relational (>= 2.1.4) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.EntityFrameworkCore.InMemory (2.1.4) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Relational (2.1.4) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.SqlServer (2.1.4) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Relational (>= 2.1.4) - restriction: >= netstandard2.0
-      System.Data.SqlClient (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Tools (2.1.4) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Design (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.Abstractions (2.1.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.Memory (2.1.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Caching.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.SqlServer (2.1.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Caching.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-      System.Data.SqlClient (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Binder (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.CommandLine (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.EnvironmentVariables (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.FileExtensions (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Ini (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Json (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
-      Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.KeyPerFile (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.UserSecrets (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Json (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Xml (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
-      System.Security.Cryptography.Xml (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.DependencyInjection (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.DependencyInjection.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.Extensions.DependencyModel (2.1) - restriction: >= netcoreapp1.0
-      Microsoft.DotNet.PlatformAbstractions (>= 2.1) - restriction: || (>= net451) (>= netstandard1.3)
-      Newtonsoft.Json (>= 9.0.1) - restriction: || (>= net451) (>= netstandard1.3)
-      System.Diagnostics.Debug (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
-      System.Dynamic.Runtime (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
-      System.Linq (>= 4.1) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
-    Microsoft.Extensions.DiagnosticAdapter (2.1) - restriction: >= netcoreapp3.0
-      System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.FileProviders.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Composite (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Embedded (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Physical (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileSystemGlobbing (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.Extensions.Hosting (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Hosting.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Http (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Identity.Core (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-      System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Identity.Stores (2.1.3) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Identity.Core (>= 2.1.3) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-      System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Localization (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Localization.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Localization.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.Extensions.Logging (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.Extensions.Logging.Configuration (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Console (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Debug (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.EventSource (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-      Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.TraceSource (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.ObjectPool (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.Extensions.Options (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Options.ConfigurationExtensions (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Primitives (2.1.1) - restriction: >= netcoreapp3.0
-      System.Memory (>= 4.5.1) - restriction: >= netstandard2.0
-      System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.WebEncoders (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-      System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.IdentityModel.JsonWebTokens (5.3) - restriction: >= netcoreapp3.0
-      Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-      Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Logging (5.3) - restriction: >= netcoreapp3.0
-      System.Diagnostics.Tracing (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-      System.Globalization (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-      System.IO (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-      System.IO.FileSystem (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Protocols (5.3) - restriction: >= netcoreapp3.0
-      Microsoft.IdentityModel.Logging (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-      Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-      System.Collections.Specialized (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-      System.Diagnostics.Contracts (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-      System.Net.Http (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Protocols.OpenIdConnect (5.3) - restriction: >= netcoreapp3.0
-      Microsoft.IdentityModel.Protocols (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-      Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-      System.Dynamic.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-      System.IdentityModel.Tokens.Jwt (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Protocols.WsFederation (5.3) - restriction: >= netcoreapp3.0
-      Microsoft.IdentityModel.Protocols (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-      Microsoft.IdentityModel.Tokens.Saml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-      Microsoft.IdentityModel.Xml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-      System.Xml.XmlDocument (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Tokens (5.3) - restriction: >= netcoreapp3.0
-      Microsoft.IdentityModel.Logging (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-      Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-      System.Collections (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-      System.Diagnostics.Tools (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-      System.Reflection (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-      System.Runtime.InteropServices (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-      System.Runtime.InteropServices.RuntimeInformation (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-      System.Runtime.Serialization.Xml (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-      System.Security.Claims (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-      System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-      System.Text.RegularExpressions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-      System.Threading (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Tokens.Saml (5.3) - restriction: >= netcoreapp3.0
-      Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-      Microsoft.IdentityModel.Xml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Xml (5.3) - restriction: >= netcoreapp3.0
-      Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.Net.Http.Headers (2.1.1) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-      System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.NET.Test.Sdk (15.9)
-      Microsoft.CodeCoverage (>= 15.9) - restriction: || (>= net45) (>= netcoreapp1.0)
-      Microsoft.TestPlatform.TestHost (>= 15.9) - restriction: >= netcoreapp1.0
+    Microsoft.NET.Test.Sdk (16.4)
+      Microsoft.CodeCoverage (>= 16.4) - restriction: || (>= net45) (>= netcoreapp2.1)
+      Microsoft.TestPlatform.TestHost (>= 16.4) - restriction: >= netcoreapp2.1
       Newtonsoft.Json (>= 9.0.1) - restriction: >= uap10.0
       System.ComponentModel.Primitives (>= 4.1) - restriction: >= uap10.0
       System.ComponentModel.TypeConverter (>= 4.1) - restriction: >= uap10.0
       System.Runtime.InteropServices.RuntimeInformation (>= 4.0) - restriction: >= uap10.0
-    Microsoft.NETCore.Platforms (2.1.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461) (< netstandard1.2)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5) (< netstandard1.6)) (&& (< net45) (>= net461) (< netstandard1.5)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (>= netcoreapp1.1)) (&& (>= net461) (< netstandard1.0) (>= netstandard1.6)) (&& (>= net461) (< netstandard1.3) (>= netstandard1.6) (>= wpa81)) (&& (>= net461) (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (&& (>= net461) (>= netstandard1.6) (< portable-net45+win8+wpa81)) (&& (>= net461) (>= netstandard1.6) (>= uap10.1)) (&& (>= net461) (>= netstandard1.6) (>= wp8)) (>= netcoreapp1.0) (&& (>= netcoreapp1.1) (>= netstandard2.0)) (&& (< netstandard1.0) (>= netstandard2.0) (< portable-net45+win8)) (&& (< netstandard1.0) (>= netstandard2.0) (>= win8)) (&& (< netstandard1.0) (>= netstandard2.0) (< win8)) (&& (< netstandard1.3) (>= netstandard2.0) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= netstandard2.0) (>= uap10.0)) (&& (>= netstandard2.0) (< portable-net45+win8+wpa81)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= wp8))
-    Microsoft.NETCore.Targets (2.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.2)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5) (< netstandard1.6)) (&& (< net45) (>= net461) (< netstandard1.5)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (>= net461) (>= netcoreapp1.1)) (>= netcoreapp1.0) (&& (>= netcoreapp1.1) (>= netstandard2.0))
-    Microsoft.TestPlatform.ObjectModel (15.9) - restriction: >= netcoreapp1.0
-      NETStandard.Library (>= 1.6) - restriction: && (< net451) (>= netstandard1.5)
-      System.ComponentModel.EventBasedAsync (>= 4.0.11) - restriction: && (< net451) (>= netstandard1.5)
-      System.ComponentModel.TypeConverter (>= 4.1) - restriction: || (&& (< net451) (>= netstandard1.4) (< netstandard1.5)) (&& (< net451) (>= netstandard1.5))
-      System.Diagnostics.Process (>= 4.1) - restriction: && (< net451) (>= netstandard1.5)
-      System.Diagnostics.TextWriterTraceListener (>= 4.0) - restriction: && (< net451) (>= netstandard1.5)
-      System.Diagnostics.TraceSource (>= 4.0) - restriction: && (< net451) (>= netstandard1.5)
-      System.Reflection.Metadata (>= 1.3) - restriction: || (>= net451) (>= netstandard1.5)
-      System.Reflection.TypeExtensions (>= 4.1) - restriction: && (< net451) (>= netstandard1.5)
-      System.Runtime.InteropServices.RuntimeInformation (>= 4.0) - restriction: || (&& (< net451) (>= netstandard1.4) (< netstandard1.5)) (&& (< net451) (>= netstandard1.5))
-      System.Runtime.Loader (>= 4.0) - restriction: && (< net451) (>= netstandard1.5)
-      System.Runtime.Serialization.Json (>= 4.0.2) - restriction: && (< net451) (>= netstandard1.5)
-      System.Runtime.Serialization.Primitives (>= 4.1.1) - restriction: && (< net451) (>= netstandard1.5)
-      System.Threading.Thread (>= 4.0) - restriction: && (< net451) (>= netstandard1.5)
-      System.Xml.XPath.XmlDocument (>= 4.0.1) - restriction: && (< net451) (>= netstandard1.5)
-    Microsoft.TestPlatform.TestHost (15.9) - restriction: >= netcoreapp1.0
-      Microsoft.Extensions.DependencyModel (>= 1.0.3) - restriction: >= netcoreapp1.0
-      Microsoft.TestPlatform.ObjectModel (>= 15.9) - restriction: || (>= netcoreapp1.0) (>= uap10.0)
-      Newtonsoft.Json (>= 9.0.1) - restriction: || (>= netcoreapp1.0) (>= uap10.0)
-    Microsoft.Win32.Primitives (4.3) - restriction: >= netcoreapp1.0
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    Microsoft.Win32.Registry (4.5) - restriction: >= netcoreapp1.0
-      System.Security.AccessControl (>= 4.5) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Security.Principal.Windows (>= 4.5) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-    NETStandard.Library (2.0.3) - restriction: || (&& (< net35) (>= netstandard1.1) (< netstandard2.0)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= netstandard2.0)) (&& (< net452) (>= netstandard1.1)) (>= netcoreapp1.0)
+    Microsoft.NETCore.Platforms (3.1) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net40) (>= net45) (< netstandard1.3) (>= netstandard2.0)) (&& (< net40) (>= net46) (< netstandard1.4) (>= netstandard2.0)) (&& (< net40) (>= net461)) (&& (< net40) (< netcoreapp2.1) (>= netstandard2.0) (< netstandard2.1)) (&& (< net40) (< netstandard1.0) (>= netstandard2.0) (< portable-net45+win8)) (&& (< net40) (< netstandard1.0) (>= netstandard2.0) (< win8)) (&& (< net40) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< net40) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< net40) (< netstandard1.4) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< net40) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< net40) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< net40) (>= netstandard2.0) (< portable-net45+win8+wpa81)) (&& (< net45) (>= net461) (< netstandard1.2)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5) (< netstandard1.6)) (&& (< net45) (>= net461) (< netstandard1.5)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (>= net461) (>= netcoreapp1.1)) (&& (>= net461) (>= netcoreapp2.0)) (&& (>= net461) (>= netcoreapp2.1)) (&& (>= net461) (< netstandard1.0) (>= win8)) (&& (>= net461) (< netstandard1.3) (>= wpa81)) (&& (>= net461) (< netstandard1.5) (>= uap10.0)) (&& (>= net461) (>= uap10.1)) (&& (>= net461) (>= wp8)) (&& (>= netcoreapp1.1) (>= netstandard2.0)) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (>= netcoreapp2.1) (< netcoreapp3.0)) (&& (< netstandard1.0) (>= netstandard2.0) (>= win8)) (&& (< netstandard1.3) (>= netstandard2.0) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= netstandard2.0) (>= uap10.0)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= wp8))
+    Microsoft.NETCore.Targets (3.1) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461) (< netstandard1.2)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5) (< netstandard1.6)) (&& (< net45) (>= net461) (< netstandard1.5)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (>= net461) (>= netcoreapp1.1)) (&& (>= netcoreapp1.1) (>= netstandard2.0))
+    Microsoft.TestPlatform.ObjectModel (16.4) - restriction: >= netcoreapp2.1
+      NuGet.Frameworks (>= 5.0) - restriction: || (>= net451) (>= netstandard2.0)
+    Microsoft.TestPlatform.TestHost (16.4) - restriction: >= netcoreapp2.1
+      Microsoft.TestPlatform.ObjectModel (>= 16.4) - restriction: || (>= netcoreapp2.1) (>= uap10.0)
+      Newtonsoft.Json (>= 9.0.1) - restriction: || (>= netcoreapp2.1) (>= uap10.0)
+    Microsoft.Win32.Registry (4.7) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      System.Buffers (>= 4.5) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+      System.Memory (>= 4.5.3) - restriction: || (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (>= uap10.1)
+      System.Security.AccessControl (>= 4.7) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+      System.Security.Principal.Windows (>= 4.7) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+    NETStandard.Library (2.0.3) - restriction: || (&& (< net35) (>= netstandard1.1) (< netstandard2.0)) (&& (< net40) (>= net461)) (&& (< net40) (< netcoreapp2.1) (>= netstandard2.0) (< netstandard2.1)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= netstandard2.0)) (&& (< net452) (>= netstandard1.1))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (>= net45) (< netstandard1.3)) (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.4)) (>= net461) (>= netcoreapp2.0) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8) (< win8)) (&& (< netstandard1.0) (< portable-net45+win8) (>= portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard1.3) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= uap10.0)) (>= uap10.1) (>= wp8)
-    Newtonsoft.Json (11.0.2) - restriction: || (>= net461) (>= netcoreapp1.0) (>= netstandard2.0) (>= uap10.0)
-    Newtonsoft.Json.Bson (1.0.1) - restriction: >= netcoreapp3.0
-      NETStandard.Library (>= 1.6.1) - restriction: && (< net45) (>= netstandard1.3)
-      Newtonsoft.Json (>= 10.0.1) - restriction: || (>= net45) (>= netstandard1.3)
-    Remotion.Linq (2.2) - restriction: >= netcoreapp3.0
-      System.Collections (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
-      System.Diagnostics.Debug (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
-      System.Linq (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
-      System.Linq.Expressions (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
-      System.Linq.Queryable (>= 4.0.1) - restriction: && (< net35) (>= netstandard1.0)
-      System.ObjectModel (>= 4.0.12) - restriction: && (< net35) (>= netstandard1.0)
-      System.Reflection (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
-      System.Reflection.Extensions (>= 4.0.1) - restriction: && (< net35) (>= netstandard1.0)
-      System.Runtime (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
-      System.Runtime.Extensions (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
-      System.Threading (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
-    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.native.System (4.3.1) - restriction: >= netcoreapp1.0
-      Microsoft.NETCore.Platforms (>= 1.1.1)
-      Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Data.SqlClient.sni (4.5) - restriction: >= netcoreapp3.0
-      runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (>= 4.4)
-      runtime.win-x64.runtime.native.System.Data.SqlClient.sni (>= 4.4)
-      runtime.win-x86.runtime.native.System.Data.SqlClient.sni (>= 4.4)
-    runtime.native.System.IO.Compression (4.3.2) - restriction: >= netcoreapp3.0
-      Microsoft.NETCore.Platforms (>= 1.1.1)
-      Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Net.Http (4.3.1) - restriction: >= netcoreapp3.0
-      Microsoft.NETCore.Platforms (>= 1.1.1)
-      Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.0
-      runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (>= 4.3.1)
-    runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-      runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-      runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-      runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-      runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-      runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-      runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-      runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-      runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-      runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-      runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-      runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-      runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-      runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-      runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-      runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.0
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
-    runtime.win-x64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
-    runtime.win-x86.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
-    System.AppContext (4.3) - restriction: >= netcoreapp3.0
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Buffers (4.5) - restriction: >= netcoreapp3.0
-    System.Collections (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Collections.Concurrent (4.3) - restriction: >= netcoreapp1.0
-      System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Diagnostics.Tracing (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
-      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
-    System.Collections.Immutable (1.5) - restriction: >= netcoreapp3.0
-    System.Collections.NonGeneric (4.3) - restriction: >= netcoreapp3.0
-      System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Collections.Specialized (4.3) - restriction: >= netcoreapp3.0
-      System.Collections.NonGeneric (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Globalization.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.ComponentModel.Annotations (4.5) - restriction: >= netcoreapp3.0
-    System.ComponentModel.EventBasedAsync (4.3) - restriction: >= netcoreapp1.0
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
+    Newtonsoft.Json (12.0.3) - restriction: || (>= net461) (>= netstandard2.0) (>= uap10.0)
+    NuGet.Frameworks (5.3.1) - restriction: >= netcoreapp2.1
+    System.Buffers (4.5) - restriction: || (&& (< monoandroid) (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (>= monotouch) (>= netstandard2.0)) (&& (>= net45) (< netstandard1.1) (>= netstandard2.0)) (&& (>= net45) (< netstandard1.3) (>= netstandard2.0)) (&& (< net45) (>= net46) (>= netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.1) (>= netstandard2.0)) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0)) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (>= xamarinios) (>= xamarinmac)
+    System.Collections (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netcoreapp1.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461))
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+    System.Collections.Immutable (1.7) - restriction: || (&& (>= net45) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0)) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (< netstandard1.1) (>= netstandard2.0) (< win8))
+      System.Memory (>= 4.5.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= net46) (>= uap10.1)
+    System.ComponentModel.Annotations (4.7) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
     System.ComponentModel.Primitives (4.3) - restriction: >= uap10.0
-    System.ComponentModel.TypeConverter (4.3) - restriction: || (>= netcoreapp1.0) (>= uap10.0)
+    System.ComponentModel.TypeConverter (4.3) - restriction: >= uap10.0
       System.ComponentModel.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.5) (< win8)) (&& (>= net45) (< netstandard1.5)) (>= net462) (&& (< netstandard1.0) (>= win8)) (>= wp8) (>= wpa81)
-    System.Console (4.3.1) - restriction: >= netcoreapp3.0
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      Microsoft.NETCore.Targets (>= 1.1.2) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Data.SqlClient (4.5.1) - restriction: >= netcoreapp3.0
-      Microsoft.Win32.Registry (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
-      runtime.native.System.Data.SqlClient.sni (>= 4.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net451) (>= netstandard1.3) (< netstandard2.0) (< win81) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
-      System.Security.Principal.Windows (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
-      System.Text.Encoding.CodePages (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
-    System.Diagnostics.Contracts (4.3) - restriction: >= netcoreapp3.0
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Diagnostics.Debug (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (>= netstandard1.6)) (>= netcoreapp1.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Diagnostics.DiagnosticSource (4.5.1) - restriction: >= netcoreapp3.0
-    System.Diagnostics.FileVersionInfo (4.3) - restriction: >= netcoreapp3.0
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.IO.FileSystem (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.IO.FileSystem.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection.Metadata (>= 1.4.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.Process (4.3) - restriction: >= netcoreapp1.0
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      Microsoft.Win32.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      Microsoft.Win32.Registry (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4))
-      System.IO.FileSystem (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO.FileSystem.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4))
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Handles (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4))
-      System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Text.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4))
-      System.Text.Encoding.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading.Thread (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading.ThreadPool (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.StackTrace (4.3) - restriction: >= netcoreapp3.0
-      System.IO.FileSystem (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.Metadata (>= 1.4.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.TextWriterTraceListener (4.3) - restriction: >= netcoreapp1.0
-      System.Diagnostics.TraceSource (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
-      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.Tools (4.3) - restriction: >= netcoreapp3.0
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Diagnostics.TraceSource (4.3) - restriction: >= netcoreapp1.0
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.Tracing (4.3) - restriction: >= netcoreapp3.0
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Dynamic.Runtime (4.3) - restriction: >= netcoreapp3.0
-      System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Linq (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Linq.Expressions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.ObjectModel (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Reflection (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Reflection.Emit (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.TypeExtensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Globalization (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Globalization.Calendars (4.3) - restriction: >= netcoreapp3.0
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Globalization.Extensions (4.3) - restriction: >= netcoreapp3.0
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.IdentityModel.Tokens.Jwt (5.3) - restriction: >= netcoreapp3.0
-      Microsoft.IdentityModel.JsonWebTokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-      Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-      Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    System.Interactive.Async (3.2) - restriction: >= netcoreapp3.0
-    System.IO (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-      System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-      System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.IO.Compression (4.3) - restriction: >= netcoreapp3.0
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System.IO.Compression (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Buffers (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
-      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime.Handles (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime.InteropServices (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
-      System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.IO.FileSystem (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
+    System.Diagnostics.Debug (4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461) (>= netstandard1.6))
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+    System.Diagnostics.DiagnosticSource (4.7) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      System.Memory (>= 4.5.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (>= net45) (< netstandard1.3)) (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= net46) (>= uap10.1)
+    System.Globalization (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netcoreapp1.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461))
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+    System.IO (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461))
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
+      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
+      System.Text.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
+      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
+    System.IO.FileSystem (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1142,364 +200,130 @@ NUGET
       System.Runtime.Handles (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.IO.FileSystem.Primitives (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
+    System.IO.FileSystem.Primitives (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461))
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.IO.Pipelines (4.5.2) - restriction: >= netstandard2.0
-    System.Linq (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
-      System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.6) (< win8) (< wp8) (< wpa81))
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.6) (< win8) (< wp8) (< wpa81))
-      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Linq.Expressions (4.3) - restriction: >= netcoreapp3.0
-      System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Linq (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.ObjectModel (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-      System.Reflection.Emit (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection.Emit.Lightweight (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection.TypeExtensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Linq.Queryable (4.3) - restriction: >= netcoreapp3.0
-      System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Linq (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Linq.Expressions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Reflection (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Memory (4.5.1) - restriction: >= netcoreapp3.0
-    System.Net.Http (4.3.4) - restriction: >= netcoreapp3.0
-      Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-      runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System.Net.Http (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.2) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-      System.Diagnostics.DiagnosticSource (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-      System.Diagnostics.Tracing (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-      System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-      System.Globalization.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-      System.IO.FileSystem (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Net.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-      System.Runtime.Handles (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-      System.Runtime.InteropServices (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-      System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Security.Cryptography.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (>= net46)
-      System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-      System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-      System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-    System.Net.Primitives (4.3) - restriction: >= netcoreapp3.0
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
-      System.Runtime.Handles (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Net.WebSockets.WebSocketProtocol (4.5.2) - restriction: >= netcoreapp3.0
-    System.Numerics.Vectors (4.5) - restriction: >= netcoreapp3.0
-    System.ObjectModel (4.3) - restriction: >= netcoreapp3.0
-      System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Private.DataContractSerialization (4.3) - restriction: >= netcoreapp1.0
-      System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Collections.Concurrent (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Linq (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.Emit.Lightweight (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection.TypeExtensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime.Serialization.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
-      System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Text.Encoding.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Text.RegularExpressions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Xml.ReaderWriter (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Xml.XDocument (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Xml.XmlDocument (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
-      System.Xml.XmlSerializer (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Reflection (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios)) (&& (< net45) (>= net461)) (&& (< net45) (>= net47)) (>= netcoreapp1.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-      System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-      System.Reflection.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Reflection.Emit (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.0)
-      System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Reflection.Emit.ILGeneration (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios)) (&& (< net45) (>= net461)) (&& (< net45) (>= net47)) (>= netcoreapp1.0)
-      System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< wp8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< wp8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< wp8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Reflection.Emit.Lightweight (4.3) - restriction: || (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp1.0)
-      System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< wp8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< wp8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< wp8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< wp8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Reflection.Extensions (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Reflection.Metadata (1.6) - restriction: >= netcoreapp1.0
-    System.Reflection.Primitives (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios)) (&& (< net45) (>= net461)) (&& (< net45) (>= net47)) (>= netcoreapp1.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Reflection.TypeExtensions (4.5.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
-    System.Resources.ResourceManager (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Runtime (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= net461) (< netstandard1.6)) (&& (< net45) (>= net461) (< netstandard2.0)) (&& (< net45) (>= net47)) (&& (>= net461) (>= netcoreapp1.1)) (>= netcoreapp1.0) (&& (>= netcoreapp1.1) (>= netstandard2.0))
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Runtime.CompilerServices.Unsafe (4.5.2) - restriction: >= netcoreapp3.0
-    System.Runtime.Extensions (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Runtime.Handles (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
+    System.IO.Pipelines (4.7) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0)) (>= netcoreapp3.1)
+    System.Linq (4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461))
+      System.Collections (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.6) (< win8) (< wp8) (< wpa81))
+      System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.6) (< win8) (< wp8) (< wpa81))
+      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+    System.Memory (4.5.3) - restriction: || (&& (>= net45) (< netstandard1.3) (>= netstandard2.0)) (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< netstandard2.1)) (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (>= net46) (>= netstandard2.0)) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (>= net461) (>= netcoreapp2.0)) (&& (>= net461) (>= netstandard2.0)) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp3.0) (>= netstandard2.0)) (&& (>= netstandard2.0) (>= uap10.1))
+      System.Buffers (>= 4.4) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (< uap10.1) (>= wpa81)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+      System.Numerics.Vectors (>= 4.4) - restriction: || (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= net461)
+      System.Runtime.CompilerServices.Unsafe (>= 4.5.2) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+    System.Numerics.Vectors (4.5) - restriction: || (&& (< net45) (>= net46) (>= netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (>= net461) (>= netstandard2.0)) (&& (>= netstandard2.0) (>= uap10.1))
+    System.Reflection (4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461))
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
+      System.IO (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
+      System.Reflection.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
+      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
+    System.Reflection.Emit (4.7) - restriction: || (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47)
+      System.Reflection.Emit.ILGeneration (>= 4.7) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarinios) (< xamarinmac)) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= uap10.1)
+    System.Reflection.Emit.ILGeneration (4.7) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (< net45) (>= net461)) (&& (< net45) (>= net47) (>= netstandard2.0)) (&& (< net45) (>= net47) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarinios) (< xamarinmac)) (&& (>= net461) (< netstandard1.1)) (&& (>= net461) (< netstandard2.0) (>= wpa81)) (&& (>= net461) (< portable-net45+wp8)) (&& (>= net461) (>= uap10.1)) (&& (>= net47) (< netstandard2.0) (>= wpa81)) (&& (>= net47) (< portable-net45+wp8)) (&& (>= net47) (>= uap10.1)) (&& (>= netstandard2.0) (< portable-net45+wp8) (>= win8)) (&& (>= netstandard2.0) (< portable-net45+wp8) (< win8)) (&& (>= netstandard2.0) (>= uap10.1))
+    System.Reflection.Emit.Lightweight (4.7) - restriction: || (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47)
+      System.Reflection.Emit.ILGeneration (>= 4.7) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< netstandard2.0) (< win8) (< wp8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarinios) (< xamarinmac)) (&& (< netstandard2.0) (>= wpa81)) (&& (>= portable-net45+win8+wp8+wpa81) (< portable-net45+wp8) (< win8)) (&& (< portable-net45+wp8) (>= win8)) (>= uap10.1)
+    System.Reflection.Extensions (4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461))
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+    System.Reflection.Metadata (1.8) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      System.Collections.Immutable (>= 1.7) - restriction: || (>= net45) (&& (< netcoreapp3.1) (>= netstandard2.0)) (&& (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (&& (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81))
+    System.Reflection.Primitives (4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461))
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+    System.Reflection.TypeExtensions (4.7) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461))
+    System.Resources.ResourceManager (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netcoreapp1.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461))
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+    System.Runtime (4.3.1) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461)) (&& (>= net461) (>= netcoreapp1.1)) (&& (>= netcoreapp1.1) (>= netstandard2.0))
+      Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
+      Microsoft.NETCore.Targets (>= 1.1.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
+    System.Runtime.CompilerServices.Unsafe (4.7) - restriction: || (&& (< monoandroid) (< netstandard1.0) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (>= monotouch) (>= netstandard2.0)) (&& (>= net45) (>= netcoreapp2.0) (< netstandard1.3)) (&& (>= net45) (< netstandard1.1) (>= netstandard2.0)) (&& (>= net45) (< netstandard1.3) (>= netstandard2.0)) (&& (>= net45) (< netstandard1.3) (>= xamarinios)) (&& (>= net45) (< netstandard1.3) (>= xamarinmac)) (&& (< net45) (>= net46) (>= netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (>= net46) (>= netcoreapp2.0)) (&& (>= net46) (< netstandard1.1) (>= netstandard2.0)) (&& (>= net46) (>= xamarinios)) (&& (>= net46) (>= xamarinmac)) (&& (>= net461) (>= netcoreapp2.0)) (&& (>= net461) (< netstandard1.0)) (&& (>= net461) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (&& (>= net461) (>= wp8)) (&& (>= net461) (>= xamarinios)) (&& (>= net461) (>= xamarinmac)) (>= net47) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (>= netcoreapp2.0) (>= uap10.1)) (&& (< netcoreapp3.0) (>= netstandard2.0)) (&& (< netstandard1.0) (>= netstandard2.0) (>= win8)) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= wp8)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (&& (>= uap10.1) (>= xamarinios)) (&& (>= uap10.1) (>= xamarinmac))
+    System.Runtime.Extensions (4.3.1) - restriction: || (&& (< monoandroid) (< net45) (< netcoreapp1.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461))
+      Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
+      Microsoft.NETCore.Targets (>= 1.1.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
+      System.Runtime (>= 4.3.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
+    System.Runtime.Handles (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Runtime.InteropServices (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp1.1)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp1.1)
-      System.Reflection (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp1.1)
-      System.Reflection.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp1.1)
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= net462) (>= netcoreapp1.1)
-      System.Runtime.Handles (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp1.1)
-    System.Runtime.InteropServices.RuntimeInformation (4.3) - restriction: || (>= netcoreapp1.0) (>= uap10.0)
-    System.Runtime.Loader (4.3) - restriction: >= netcoreapp1.0
-      System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Runtime.Numerics (4.3) - restriction: >= netcoreapp3.0
-      System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
-      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Runtime.Serialization.Json (4.3) - restriction: >= netcoreapp1.0
-      System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Private.DataContractSerialization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Runtime.Serialization.Primitives (4.3) - restriction: >= netcoreapp1.0
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Runtime.Serialization.Xml (4.3) - restriction: >= netcoreapp3.0
-      System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Private.DataContractSerialization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Runtime.Serialization.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
-      System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Xml.ReaderWriter (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Security.AccessControl (4.5) - restriction: >= netcoreapp3.0
-      Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
-      System.Security.Principal.Windows (>= 4.5) - restriction: || (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0)
-    System.Security.Claims (4.3) - restriction: >= netcoreapp3.0
-      System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Security.Principal (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.Algorithms (4.3.1) - restriction: >= netcoreapp3.0
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      runtime.native.System.Security.Cryptography.Apple (>= 4.3.1) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.2) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Collections (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net463)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net463)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime.Handles (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime.InteropServices (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime.Numerics (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net463)
-      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net46) (< netstandard1.4)) (&& (>= net461) (< netstandard1.6)) (>= net463)
-      System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Cryptography.Cng (4.5) - restriction: >= netcoreapp3.0
-    System.Security.Cryptography.Csp (4.3) - restriction: >= netcoreapp3.0
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Handles (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
-      System.Security.Cryptography.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
-      System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.Encoding (4.3) - restriction: >= netcoreapp3.0
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Collections.Concurrent (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Linq (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Handles (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Security.Cryptography.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.OpenSsl (4.5) - restriction: >= netcoreapp3.0
-    System.Security.Cryptography.Pkcs (4.5.1) - restriction: >= netcoreapp3.0
-      System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netcoreapp3.0
-    System.Security.Cryptography.Primitives (4.3) - restriction: >= netcoreapp3.0
-      System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.X509Certificates (4.3.2) - restriction: >= netcoreapp3.0
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      runtime.native.System (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System.Net.Http (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.2) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Diagnostics.Debug (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Globalization.Calendars (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.IO.FileSystem (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.IO.FileSystem.Primitives (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime.Handles (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime.InteropServices (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime.Numerics (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net46) (< netstandard1.4)) (>= net461)
-      System.Security.Cryptography.Cng (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Security.Cryptography.Csp (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net46) (< netstandard1.4)) (>= net461)
-      System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Cryptography.Xml (4.5) - restriction: >= netcoreapp3.0
-      System.Security.Cryptography.Pkcs (>= 4.5) - restriction: && (< net461) (>= netstandard2.0)
-      System.Security.Permissions (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Security.Permissions (4.5) - restriction: >= netcoreapp3.0
-      System.Security.AccessControl (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Security.Principal (4.3) - restriction: >= netcoreapp3.0
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Principal.Windows (4.5.1) - restriction: >= netcoreapp3.0
-      Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
-    System.Text.Encoding (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5)) (&& (< net45) (>= net461) (< netstandard1.5)) (>= netcoreapp1.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Text.Encoding.CodePages (4.5) - restriction: >= netcoreapp3.0
-      Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
-      System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: || (&& (< net46) (>= netstandard2.0) (< xamarinios)) (>= net461) (>= netcoreapp2.0)
-    System.Text.Encoding.Extensions (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Text.Encodings.Web (4.5) - restriction: >= netcoreapp3.0
-    System.Text.RegularExpressions (4.3) - restriction: || (>= net461) (>= netcoreapp1.0) (>= netstandard2.0)
-      System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (>= netcoreapp1.1)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Threading (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Threading.Channels (4.5) - restriction: >= netcoreapp3.0
-    System.Threading.Tasks (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5)) (&& (< net45) (>= net461) (< netstandard1.5)) (&& (< net45) (>= net461) (>= netstandard1.6)) (>= netcoreapp1.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Threading.Tasks.Extensions (4.5.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.0)
-    System.Threading.Tasks.Parallel (4.3) - restriction: >= netcoreapp3.0
-      System.Collections.Concurrent (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Diagnostics.Tracing (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
-      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
-    System.Threading.Thread (4.3) - restriction: >= netcoreapp1.0
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Threading.ThreadPool (4.3) - restriction: >= netcoreapp1.0
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Handles (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.ValueTuple (4.5) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.6) (>= netstandard2.0)) (>= net461) (>= netcoreapp3.0)
-    System.Xml.ReaderWriter (4.3.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
-      System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.IO.FileSystem (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.IO.FileSystem.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime.InteropServices (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Text.Encoding.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Text.RegularExpressions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Threading.Tasks.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Xml.XDocument (4.3) - restriction: >= netcoreapp1.0
-      System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Diagnostics.Tools (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Reflection (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Xml.ReaderWriter (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Xml.XmlDocument (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
+    System.Runtime.InteropServices (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461))
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp1.1)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp1.1)
+      System.Reflection (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp1.1)
+      System.Reflection.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp1.1)
+      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= net462) (>= netcoreapp1.1)
+      System.Runtime.Handles (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp1.1)
+    System.Runtime.InteropServices.RuntimeInformation (4.3) - restriction: >= uap10.0
+    System.Security.AccessControl (4.7) - restriction: || (&& (>= monotouch) (>= netstandard2.0)) (&& (< net46) (< netcoreapp3.0) (>= netstandard2.0)) (&& (>= net461) (>= netcoreapp2.0)) (&& (>= net461) (>= netstandard2.0)) (&& (>= netcoreapp2.0) (< netcoreapp3.0)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (>= xamarinios) (>= xamarinmac)
+      Microsoft.NETCore.Platforms (>= 3.1) - restriction: >= netcoreapp2.0
+      System.Security.Principal.Windows (>= 4.7) - restriction: || (&& (>= net46) (< netstandard2.0)) (&& (< net46) (>= netstandard1.3) (< netstandard2.0) (< uap10.1)) (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0)
+    System.Security.Cryptography.Cng (4.7) - restriction: || (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarinios) (< xamarinmac)) (&& (>= netcoreapp2.0) (< netcoreapp2.1) (< netstandard2.1)) (&& (< netcoreapp2.0) (>= netstandard2.1)) (&& (>= netcoreapp2.1) (< netstandard2.1))
+      Microsoft.NETCore.Platforms (>= 3.1) - restriction: && (>= netcoreapp2.0) (< netcoreapp2.1) (< netstandard2.1)
+    System.Security.Cryptography.Pkcs (4.7) - restriction: && (< net461) (< netcoreapp3.0) (>= netstandard2.0)
+      System.Buffers (>= 4.5) - restriction: && (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarinios) (< xamarinmac)
+      System.Memory (>= 4.5.3) - restriction: || (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarinios) (< xamarinmac)) (&& (>= netcoreapp2.0) (< netcoreapp2.1) (< netstandard2.1)) (>= uap10.1)
+      System.Security.Cryptography.Cng (>= 4.7) - restriction: || (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarinios) (< xamarinmac)) (&& (>= netcoreapp2.0) (< netcoreapp2.1) (< netstandard2.1)) (&& (< netcoreapp2.0) (>= netstandard2.1)) (&& (>= netcoreapp2.1) (< netstandard2.1)) (>= netcoreapp3.0)
+    System.Security.Cryptography.Xml (4.7) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      System.Security.Cryptography.Pkcs (>= 4.7) - restriction: && (< net461) (>= netstandard2.0)
+      System.Security.Permissions (>= 4.7) - restriction: || (>= net461) (>= netstandard2.0)
+    System.Security.Permissions (4.7) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      System.Security.AccessControl (>= 4.7) - restriction: || (>= net461) (>= netstandard2.0)
+    System.Security.Principal.Windows (4.7) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      Microsoft.NETCore.Platforms (>= 3.1) - restriction: || (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (>= netcoreapp2.1) (< netcoreapp3.0))
+    System.Text.Encoding (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5)) (&& (< net45) (>= net461) (< netstandard1.5))
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+    System.Text.Encoding.Extensions (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461))
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      System.Text.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+    System.Text.Encodings.Web (4.7) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+      System.Memory (>= 4.5.3) - restriction: || (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< netstandard2.1)) (>= net461) (>= uap10.1)
+    System.Text.RegularExpressions (4.3.1) - restriction: || (>= net461) (>= netstandard2.0)
+      System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Runtime (>= 4.3.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (>= netcoreapp1.1)
+      System.Runtime.Extensions (>= 4.3.1) - restriction: && (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+    System.Threading (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netcoreapp1.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461))
+      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+    System.Threading.Tasks (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5)) (&& (< net45) (>= net461) (< netstandard1.5)) (&& (< net45) (>= net461) (>= netstandard1.6))
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+    System.Threading.Tasks.Extensions (4.5.3) - restriction: || (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (&& (>= net461) (>= netstandard2.1)) (>= net47) (&& (< netcoreapp2.1) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.1))
+      System.Runtime.CompilerServices.Unsafe (>= 4.5.2) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.0) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< win8)) (>= net45) (&& (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= wp8)
+    System.ValueTuple (4.5) - restriction: || (>= net461) (>= netstandard2.0)
+    System.Xml.ReaderWriter (4.3.1) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461))
+      System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.IO (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      System.IO.FileSystem (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.IO.FileSystem.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Text.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      System.Text.Encoding.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Text.RegularExpressions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      System.Threading.Tasks.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+    System.Xml.XmlDocument (4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net461))
       System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1510,55 +334,24 @@ NUGET
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Xml.ReaderWriter (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Xml.XmlSerializer (4.3) - restriction: || (>= net461) (>= netcoreapp1.0) (>= netstandard2.0)
-      System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Linq (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection.Emit (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Reflection.TypeExtensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Text.RegularExpressions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-      System.Xml.ReaderWriter (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-      System.Xml.XmlDocument (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Xml.XPath (4.3) - restriction: >= netcoreapp1.0
-      System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Xml.ReaderWriter (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Xml.XPath.XDocument (4.3) - restriction: >= netcoreapp3.0
-      System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Linq (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Xml.ReaderWriter (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Xml.XDocument (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Xml.XPath (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
-    System.Xml.XPath.XmlDocument (4.3) - restriction: >= netcoreapp1.0
-      System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Xml.ReaderWriter (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Xml.XmlDocument (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
-      System.Xml.XPath (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
+    System.Xml.XmlSerializer (4.3) - restriction: || (>= net461) (>= netstandard2.0)
+      System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.IO (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      System.Linq (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Reflection.Emit (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Reflection.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Reflection.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Reflection.TypeExtensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Text.RegularExpressions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Xml.ReaderWriter (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+      System.Xml.XmlDocument (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
     TaskBuilder.fs (2.1) - restriction: || (>= net461) (>= netstandard2.0)
       FSharp.Core (>= 4.1.17) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6)) (&& (< net45) (>= netstandard1.6)) (&& (>= net46) (< netstandard1.6)) (>= net47)
       NETStandard.Library (>= 1.6.1) - restriction: && (< net45) (>= netstandard1.6)

--- a/src/content/None/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
+++ b/src/content/None/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>AppNamePlaceholder</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/content/None/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
+++ b/src/content/None/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>AppNamePlaceholder</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -9,8 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UsePaket)' == false OR '$(UsePaket)' == ''">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
-    <PackageReference Include="Giraffe" Version="3.4.*" />
+    <PackageReference Include="Giraffe" Version="4.0.*" />
     <PackageReference Include="TaskBuilder.fs" Version="2.1.*" />
   </ItemGroup>
 

--- a/src/content/None/src/AppNamePlaceholder/Program.fs
+++ b/src/content/None/src/AppNamePlaceholder/Program.fs
@@ -42,10 +42,10 @@ let configureCors (builder : CorsPolicyBuilder) =
            |> ignore
 
 let configureApp (app : IApplicationBuilder) =
-    let env = app.ApplicationServices.GetService<IHostingEnvironment>()
-    (match env.IsDevelopment() with
-    | true  -> app.UseDeveloperExceptionPage()
-    | false -> app.UseGiraffeErrorHandler errorHandler)
+    let env = app.ApplicationServices.GetService<IWebHostEnvironment>()
+    (match env.EnvironmentName with
+    | "Development" -> app.UseDeveloperExceptionPage()
+    | _ -> app.UseGiraffeErrorHandler(errorHandler))
         .UseHttpsRedirection()
         .UseCors(configureCors)
         .UseGiraffe(webApp)

--- a/src/content/None/src/AppNamePlaceholder/paket.references
+++ b/src/content/None/src/AppNamePlaceholder/paket.references
@@ -1,2 +1,1 @@
-Microsoft.AspNetCore.App
 Giraffe

--- a/src/content/None/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
+++ b/src/content/None/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UsePaket)' == false OR '$(UsePaket)' == ''">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.*" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.*" />
     <PackageReference Include="xunit" Version="2.4.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.*" />
   </ItemGroup>

--- a/src/content/None/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
+++ b/src/content/None/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UsePaket)' == false OR '$(UsePaket)' == ''">

--- a/src/content/Razor/paket.dependencies
+++ b/src/content/Razor/paket.dependencies
@@ -1,7 +1,6 @@
 storage: none
 source https://api.nuget.org/v3/index.json
 
-nuget Microsoft.AspNetCore.App
 nuget Giraffe
 nuget Giraffe.Razor
 nuget Microsoft.NET.Test.Sdk

--- a/src/content/Razor/paket.lock
+++ b/src/content/Razor/paket.lock
@@ -25,10 +25,10 @@ NUGET
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       System.ValueTuple (>= 4.4) - restriction: >= net461
       TaskBuilder.fs (>= 2.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNet.WebApi.Client (5.2.6) - restriction: >= netcoreapp2.1
+    Microsoft.AspNet.WebApi.Client (5.2.6) - restriction: >= netcoreapp3.0
       Newtonsoft.Json (>= 10.0.1) - restriction: && (< net45) (>= netstandard2.0)
       Newtonsoft.Json.Bson (>= 1.0.1) - restriction: && (< net45) (>= netstandard2.0)
-    Microsoft.AspNetCore (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Diagnostics (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.HostFiltering (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
@@ -52,151 +52,151 @@ NUGET
       Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.App (2.1.5)
-      Microsoft.AspNet.WebApi.Client (>= 5.2.6 < 5.3) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Antiforgery (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Facebook (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Google (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.JwtBearer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.MicrosoftAccount (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.OpenIdConnect (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.Twitter (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authentication.WsFederation (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authorization (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Authorization.Policy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.CookiePolicy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Cors (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.DataProtection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.DataProtection.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Diagnostics (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.HostFiltering (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http.Connections (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http.Connections.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Http.Features (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.HttpOverrides (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.HttpsPolicy (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Identity (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Identity.EntityFrameworkCore (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Identity.UI (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.JsonPatch (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Localization.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.MiddlewareAnalysis (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Analyzers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Formatters.Xml (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Localization (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.NodeServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Owin (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Razor.Design (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Razor.Language (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Razor.Runtime (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.ResponseCaching (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.ResponseCompression (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Rewrite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.HttpSys (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.IISIntegration (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.Kestrel (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.Session (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SignalR (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SignalR.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SignalR.Core (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4 < 1.1) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SpaServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.SpaServices.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.StaticFiles (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.WebSockets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.AspNetCore.WebUtilities (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.CodeAnalysis.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.Design (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.InMemory (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.Relational (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.SqlServer (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.EntityFrameworkCore.Tools (>= 2.1.4 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Caching.Abstractions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Caching.Memory (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Caching.SqlServer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.Binder (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.CommandLine (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.Ini (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.Json (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.KeyPerFile (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.UserSecrets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Configuration.Xml (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.DependencyInjection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.DiagnosticAdapter (>= 2.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.FileProviders.Composite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Identity.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Identity.Stores (>= 2.1.3 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Localization.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.Console (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.Debug (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.EventSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Logging.TraceSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.ObjectPool (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Options (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.Primitives (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Extensions.WebEncoders (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      Microsoft.Net.Http.Headers (>= 2.1.1 < 2.2) - restriction: >= netcoreapp2.1
-      System.IO.Pipelines (>= 4.5.2) - restriction: >= netcoreapp2.1
+      Microsoft.AspNet.WebApi.Client (>= 5.2.6 < 5.3) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Antiforgery (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Facebook (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Google (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.JwtBearer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.MicrosoftAccount (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.OpenIdConnect (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.Twitter (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authentication.WsFederation (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authorization (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Authorization.Policy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.CookiePolicy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Cors (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.DataProtection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.DataProtection.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Diagnostics (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.HostFiltering (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http.Connections (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http.Connections.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Http.Features (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.HttpOverrides (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.HttpsPolicy (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Identity (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Identity.EntityFrameworkCore (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Identity.UI (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.JsonPatch (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Localization.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.MiddlewareAnalysis (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Analyzers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Formatters.Xml (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Localization (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.NodeServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Owin (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Razor.Design (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Razor.Language (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Razor.Runtime (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.ResponseCaching (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.ResponseCompression (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Rewrite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.HttpSys (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.IISIntegration (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.Kestrel (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.Session (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SignalR (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SignalR.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SignalR.Core (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SpaServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.SpaServices.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.StaticFiles (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.WebSockets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNetCore.WebUtilities (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.CodeAnalysis.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.Design (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.InMemory (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.Relational (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.SqlServer (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.EntityFrameworkCore.Tools (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Caching.Abstractions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Caching.Memory (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Caching.SqlServer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.Binder (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.CommandLine (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.Ini (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.Json (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.KeyPerFile (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.UserSecrets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Configuration.Xml (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.DependencyInjection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.DiagnosticAdapter (>= 2.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.FileProviders.Composite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Identity.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Identity.Stores (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Localization.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.Console (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.Debug (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.EventSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Logging.TraceSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.ObjectPool (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Options (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.Primitives (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Extensions.WebEncoders (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      Microsoft.Net.Http.Headers (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
+      System.IO.Pipelines (>= 4.5.2) - restriction: >= netcoreapp3.0
     Microsoft.AspNetCore.Authentication (2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
@@ -205,60 +205,60 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.WebEncoders (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Cookies (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Cookies (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Core (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Core (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Facebook (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Facebook (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Google (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Google (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.JwtBearer (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.JwtBearer (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.OpenIdConnect (>= 5.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.MicrosoftAccount (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.MicrosoftAccount (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.OAuth (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.OAuth (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.OpenIdConnect (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.OpenIdConnect (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.OpenIdConnect (>= 5.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Twitter (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.Twitter (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.WsFederation (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authentication.WsFederation (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.WsFederation (>= 5.2) - restriction: >= netstandard2.0
       System.IdentityModel.Tokens.Jwt (>= 5.2) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.Authorization (2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authorization.Policy (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Authorization.Policy (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Authorization (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Connections.Abstractions (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Connections.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       System.IO.Pipelines (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.CookiePolicy (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.CookiePolicy (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cors (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Cors (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cryptography.Internal (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.Cryptography.KeyDerivation (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Cryptography.Internal (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Cryptography.KeyDerivation (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.DataProtection (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.DataProtection (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -268,8 +268,8 @@ NUGET
       Microsoft.Win32.Registry (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Cryptography.Xml (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.DataProtection.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.DataProtection.Extensions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.DataProtection.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.DataProtection.Extensions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.Diagnostics (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -282,11 +282,11 @@ NUGET
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
       System.Reflection.Metadata (>= 1.6) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Diagnostics.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Diagnostics.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HostFiltering (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.HostFiltering (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -309,21 +309,21 @@ NUGET
       Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Html.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Html.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Connections (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http.Connections (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authorization.Policy (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
@@ -331,54 +331,54 @@ NUGET
       Microsoft.AspNetCore.Routing (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebSockets (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Connections.Common (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http.Connections.Common (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Extensions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http.Extensions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Features (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Http.Features (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HttpOverrides (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.HttpOverrides (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HttpsPolicy (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.HttpsPolicy (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Identity (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity.EntityFrameworkCore (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Identity.EntityFrameworkCore (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Identity (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Stores (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity.UI (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Identity.UI (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Identity (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.StaticFiles (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Stores (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.JsonPatch (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.JsonPatch (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.CSharp (>= 4.5) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Localization (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Localization (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Localization.Routing (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Localization.Routing (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.MiddlewareAnalysis (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.MiddlewareAnalysis (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
@@ -395,13 +395,13 @@ NUGET
       Microsoft.AspNetCore.Razor.Design (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Abstractions (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Analyzers (2.1.3) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.Mvc.ApiExplorer (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Analyzers (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.ApiExplorer (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Core (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Core (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Authorization.Policy (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -416,24 +416,24 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5.1) - restriction: >= netstandard2.0
       System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Cors (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Cors (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Cors (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.DataAnnotations (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.DataAnnotations (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Formatters.Json (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Formatters.Json (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.JsonPatch (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Formatters.Xml (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Formatters.Xml (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Localization (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Localization (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Razor (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Razor (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Razor.Runtime (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -441,22 +441,22 @@ NUGET
       Microsoft.CodeAnalysis.Razor (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.FileProviders.Composite (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNetCore.Mvc.Razor.Extensions (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Razor.Extensions (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Razor.Language (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.Razor (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
-    Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: || (>= net461) (>= netcoreapp2.0)
       Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.1) - restriction: || (>= net461) (>= netcoreapp2.0)
-    Microsoft.AspNetCore.Mvc.RazorPages (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.RazorPages (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.TagHelpers (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.TagHelpers (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Razor.Runtime (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.ViewFeatures (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Mvc.ViewFeatures (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Antiforgery (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -465,17 +465,17 @@ NUGET
       Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.WebEncoders (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json.Bson (>= 1.0.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.NodeServices (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.NodeServices (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Console (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Owin (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Owin (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Razor (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor.Design (2.1.2) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.Razor.Language (2.1.2) - restriction: >= netcoreapp2.1
-    Microsoft.AspNetCore.Razor.Runtime (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Razor.Design (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Razor.Language (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Razor.Runtime (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Razor (>= 2.1.2) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.ResponseCaching (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -484,33 +484,33 @@ NUGET
       Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCompression (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.ResponseCompression (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNetCore.Rewrite (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Rewrite (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Routing (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Routing (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Routing.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Routing.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.HttpSys (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.HttpSys (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Win32.Registry (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.IISIntegration (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.IISIntegration (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
@@ -524,12 +524,12 @@ NUGET
       System.Numerics.Vectors (>= 4.5) - restriction: >= netstandard2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5.2) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.Kestrel (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Core (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.Kestrel.Core (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
@@ -542,30 +542,30 @@ NUGET
       System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
       System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netstandard2.0
       System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Https (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.Kestrel.Https (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Session (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.Session (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SignalR (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Connections (>= 1.0.4) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Core (>= 1.0.4) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Common (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SignalR.Common (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Core (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SignalR.Core (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Authorization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Common (>= 1.0.4) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4) - restriction: >= netstandard2.0
@@ -573,19 +573,19 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Reflection.Emit (>= 4.3) - restriction: >= netstandard2.0
       System.Threading.Channels (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Protocols.Json (1.0.4) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SignalR.Protocols.Json (1.0.4) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.SignalR.Common (>= 1.0.4) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SpaServices (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SpaServices (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.NodeServices (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SpaServices.Extensions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.SpaServices.Extensions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.SpaServices (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.StaticFiles (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebSockets (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.StaticFiles (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.StaticFiles (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -594,15 +594,15 @@ NUGET
     Microsoft.AspNetCore.TestHost (2.1.1)
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       System.IO.Pipelines (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.WebSockets (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.WebSockets (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Net.WebSockets.WebSocketProtocol (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.WebUtilities (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.AspNetCore.WebUtilities (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.CodeAnalysis.Analyzers (2.6.2) - restriction: >= netcoreapp2.1
-    Microsoft.CodeAnalysis.Common (2.9) - restriction: >= netcoreapp2.1
+    Microsoft.CodeAnalysis.Analyzers (2.6.2) - restriction: >= netcoreapp3.0
+    Microsoft.CodeAnalysis.Common (2.9) - restriction: >= netcoreapp3.0
       Microsoft.CodeAnalysis.Analyzers (>= 2.6.1) - restriction: >= netstandard1.3
       System.AppContext (>= 4.3) - restriction: >= netstandard1.3
       System.Collections (>= 4.3) - restriction: >= netstandard1.3
@@ -643,15 +643,15 @@ NUGET
       System.Xml.XDocument (>= 4.3) - restriction: >= netstandard1.3
       System.Xml.XmlDocument (>= 4.3) - restriction: >= netstandard1.3
       System.Xml.XPath.XDocument (>= 4.3) - restriction: >= netstandard1.3
-    Microsoft.CodeAnalysis.CSharp (2.9) - restriction: >= netcoreapp2.1
+    Microsoft.CodeAnalysis.CSharp (2.9) - restriction: >= netcoreapp3.0
       Microsoft.CodeAnalysis.Common (2.9)
-    Microsoft.CodeAnalysis.Razor (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.CodeAnalysis.Razor (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Razor.Language (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.Common (>= 2.8) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.CSharp (>= 2.8) - restriction: || (>= net46) (>= netstandard2.0)
     Microsoft.CodeCoverage (15.9) - restriction: || (>= net45) (>= netcoreapp1.0)
-    Microsoft.CSharp (4.5) - restriction: >= netcoreapp2.1
-    Microsoft.DotNet.PlatformAbstractions (2.1) - restriction: >= netcoreapp2.1
+    Microsoft.CSharp (4.5) - restriction: >= netcoreapp3.0
+    Microsoft.DotNet.PlatformAbstractions (2.1) - restriction: >= netcoreapp3.0
       System.AppContext (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Collections (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.3)
       System.IO (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
@@ -660,7 +660,7 @@ NUGET
       System.Runtime.Extensions (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Runtime.InteropServices (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Runtime.InteropServices.RuntimeInformation (>= 4.0) - restriction: || (>= net45) (>= netstandard1.3)
-    Microsoft.EntityFrameworkCore (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
@@ -671,135 +671,135 @@ NUGET
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5.1) - restriction: >= netstandard2.0
       System.Interactive.Async (>= 3.1.1) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Abstractions (2.1.4) - restriction: >= netcoreapp2.1
-    Microsoft.EntityFrameworkCore.Analyzers (2.1.4) - restriction: >= netcoreapp2.1
-    Microsoft.EntityFrameworkCore.Design (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore.Abstractions (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.Analyzers (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.Design (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.CSharp (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.4) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.EntityFrameworkCore.InMemory (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore.InMemory (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.EntityFrameworkCore (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Relational (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore.Relational (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.EntityFrameworkCore (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.SqlServer (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore.SqlServer (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.4) - restriction: >= netstandard2.0
       System.Data.SqlClient (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Tools (2.1.4) - restriction: >= netcoreapp2.1
+    Microsoft.EntityFrameworkCore.Tools (2.1.4) - restriction: >= netcoreapp3.0
       Microsoft.EntityFrameworkCore.Design (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.Abstractions (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Caching.Abstractions (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.Memory (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Caching.Memory (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.SqlServer (2.1.2) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Caching.SqlServer (2.1.2) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Data.SqlClient (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Binder (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.Binder (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.CommandLine (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.CommandLine (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.EnvironmentVariables (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.EnvironmentVariables (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.FileExtensions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.FileExtensions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Ini (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.Ini (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Json (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.Json (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.KeyPerFile (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.KeyPerFile (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.UserSecrets (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.UserSecrets (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Json (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Xml (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Configuration.Xml (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Security.Cryptography.Xml (>= 4.5) - restriction: >= netstandard2.0
     Microsoft.Extensions.DependencyInjection (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.DependencyInjection.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.DependencyInjection.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
     Microsoft.Extensions.DependencyModel (2.1) - restriction: >= netcoreapp1.0
       Microsoft.DotNet.PlatformAbstractions (>= 2.1) - restriction: || (>= net451) (>= netstandard1.3)
       Newtonsoft.Json (>= 9.0.1) - restriction: || (>= net451) (>= netstandard1.3)
       System.Diagnostics.Debug (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
       System.Dynamic.Runtime (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
       System.Linq (>= 4.1) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
-    Microsoft.Extensions.DiagnosticAdapter (2.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.DiagnosticAdapter (2.1) - restriction: >= netcoreapp3.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.FileProviders.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.FileProviders.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Composite (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.FileProviders.Composite (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Embedded (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.FileProviders.Embedded (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
     Microsoft.Extensions.FileProviders.Physical (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileSystemGlobbing (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.Extensions.Hosting (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.FileSystemGlobbing (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Hosting (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Hosting.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Hosting.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Http (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Http (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Identity.Core (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Identity.Core (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Identity.Stores (2.1.3) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Identity.Stores (2.1.3) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Identity.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Localization (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Localization (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Localization.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.Extensions.Logging (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Localization.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Abstractions (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.Extensions.Logging.Configuration (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Logging.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging.Configuration (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Console (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Logging.Console (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Debug (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Logging.Debug (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.EventSource (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Logging.EventSource (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.TraceSource (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Logging.TraceSource (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.ObjectPool (2.1.1) - restriction: >= netcoreapp2.1
-    Microsoft.Extensions.Options (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.ObjectPool (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Options (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Options.ConfigurationExtensions (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.Options.ConfigurationExtensions (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -807,35 +807,35 @@ NUGET
     Microsoft.Extensions.Primitives (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       System.Memory (>= 4.5.1) - restriction: >= netstandard2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.WebEncoders (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Extensions.WebEncoders (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.IdentityModel.JsonWebTokens (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.JsonWebTokens (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Logging (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Logging (5.3) - restriction: >= netcoreapp3.0
       System.Diagnostics.Tracing (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Globalization (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IO (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IO.FileSystem (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Protocols (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Protocols (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Logging (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Collections.Specialized (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Diagnostics.Contracts (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Net.Http (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Protocols.OpenIdConnect (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Protocols.OpenIdConnect (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Protocols (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Dynamic.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IdentityModel.Tokens.Jwt (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Protocols.WsFederation (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Protocols.WsFederation (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Protocols (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens.Saml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Xml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Xml.XmlDocument (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Tokens (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Tokens (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Logging (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Collections (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
@@ -851,12 +851,12 @@ NUGET
       System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Text.RegularExpressions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Threading (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Tokens.Saml (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Tokens.Saml (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Xml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Xml (5.3) - restriction: >= netcoreapp2.1
+    Microsoft.IdentityModel.Xml (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.Net.Http.Headers (2.1.1) - restriction: >= netcoreapp2.1
+    Microsoft.Net.Http.Headers (2.1.1) - restriction: >= netcoreapp3.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
     Microsoft.NET.Test.Sdk (15.9)
@@ -897,10 +897,10 @@ NUGET
     NETStandard.Library (2.0.3) - restriction: || (&& (< net35) (>= netstandard1.1) (< netstandard2.0)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= netstandard2.0)) (&& (< net452) (>= netstandard1.1)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (>= net45) (< netstandard1.3)) (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.4)) (>= net461) (>= netcoreapp2.0) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8) (< win8)) (&& (< netstandard1.0) (< portable-net45+win8) (>= portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard1.3) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= uap10.0)) (>= uap10.1) (>= wp8)
     Newtonsoft.Json (11.0.2) - restriction: || (>= net461) (>= netcoreapp1.0) (>= netstandard2.0) (>= uap10.0)
-    Newtonsoft.Json.Bson (1.0.1) - restriction: >= netcoreapp2.1
+    Newtonsoft.Json.Bson (1.0.1) - restriction: >= netcoreapp3.0
       NETStandard.Library (>= 1.6.1) - restriction: && (< net45) (>= netstandard1.3)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (>= net45) (>= netstandard1.3)
-    Remotion.Linq (2.2) - restriction: >= netcoreapp2.1
+    Remotion.Linq (2.2) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
       System.Diagnostics.Debug (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
       System.Linq (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
@@ -912,28 +912,28 @@ NUGET
       System.Runtime (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
       System.Runtime.Extensions (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
       System.Threading (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
-    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
+    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
     runtime.native.System (4.3.1) - restriction: >= netcoreapp1.0
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Data.SqlClient.sni (4.5) - restriction: >= netcoreapp2.1
+    runtime.native.System.Data.SqlClient.sni (4.5) - restriction: >= netcoreapp3.0
       runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (>= 4.4)
       runtime.win-x64.runtime.native.System.Data.SqlClient.sni (>= 4.4)
       runtime.win-x86.runtime.native.System.Data.SqlClient.sni (>= 4.4)
-    runtime.native.System.IO.Compression (4.3.2) - restriction: >= netcoreapp2.1
+    runtime.native.System.IO.Compression (4.3.2) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Net.Http (4.3.1) - restriction: >= netcoreapp2.1
+    runtime.native.System.Net.Http (4.3.1) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp2.1
+    runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.0
       runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (>= 4.3.1)
-    runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
+    runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
       runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
@@ -949,22 +949,22 @@ NUGET
       runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp2.1
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp2.1
-    runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp2.1
-    runtime.win-x64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp2.1
-    runtime.win-x86.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp2.1
-    System.AppContext (4.3) - restriction: >= netcoreapp2.1
+    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.0
+    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
+    runtime.win-x64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
+    runtime.win-x86.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
+    System.AppContext (4.3) - restriction: >= netcoreapp3.0
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Buffers (4.5) - restriction: >= netcoreapp2.1
+    System.Buffers (4.5) - restriction: >= netcoreapp3.0
     System.Collections (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -980,15 +980,15 @@ NUGET
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
-    System.Collections.Immutable (1.5) - restriction: >= netcoreapp2.1
-    System.Collections.NonGeneric (4.3) - restriction: >= netcoreapp2.1
+    System.Collections.Immutable (1.5) - restriction: >= netcoreapp3.0
+    System.Collections.NonGeneric (4.3) - restriction: >= netcoreapp3.0
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Collections.Specialized (4.3) - restriction: >= netcoreapp2.1
+    System.Collections.Specialized (4.3) - restriction: >= netcoreapp3.0
       System.Collections.NonGeneric (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -996,7 +996,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.ComponentModel.Annotations (4.5) - restriction: >= netcoreapp2.1
+    System.ComponentModel.Annotations (4.5) - restriction: >= netcoreapp3.0
     System.ComponentModel.EventBasedAsync (4.3) - restriction: >= netcoreapp1.0
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -1005,25 +1005,25 @@ NUGET
     System.ComponentModel.Primitives (4.3) - restriction: >= uap10.0
     System.ComponentModel.TypeConverter (4.3) - restriction: || (>= netcoreapp1.0) (>= uap10.0)
       System.ComponentModel.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.5) (< win8)) (&& (>= net45) (< netstandard1.5)) (>= net462) (&& (< netstandard1.0) (>= win8)) (>= wp8) (>= wpa81)
-    System.Console (4.3.1) - restriction: >= netcoreapp2.1
+    System.Console (4.3.1) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1.2) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Data.SqlClient (4.5.1) - restriction: >= netcoreapp2.1
+    System.Data.SqlClient (4.5.1) - restriction: >= netcoreapp3.0
       Microsoft.Win32.Registry (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       runtime.native.System.Data.SqlClient.sni (>= 4.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net451) (>= netstandard1.3) (< netstandard2.0) (< win81) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       System.Security.Principal.Windows (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       System.Text.Encoding.CodePages (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
-    System.Diagnostics.Contracts (4.3) - restriction: >= netcoreapp2.1
+    System.Diagnostics.Contracts (4.3) - restriction: >= netcoreapp3.0
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
     System.Diagnostics.Debug (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (>= netstandard1.6)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Diagnostics.DiagnosticSource (4.5.1) - restriction: >= netcoreapp2.1
-    System.Diagnostics.FileVersionInfo (4.3) - restriction: >= netcoreapp2.1
+    System.Diagnostics.DiagnosticSource (4.5.1) - restriction: >= netcoreapp3.0
+    System.Diagnostics.FileVersionInfo (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1055,7 +1055,7 @@ NUGET
       System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.Thread (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.ThreadPool (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.StackTrace (4.3) - restriction: >= netcoreapp2.1
+    System.Diagnostics.StackTrace (4.3) - restriction: >= netcoreapp3.0
       System.IO.FileSystem (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection.Metadata (>= 1.4.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1067,7 +1067,7 @@ NUGET
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.Tools (4.3) - restriction: >= netcoreapp2.1
+    System.Diagnostics.Tools (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1081,11 +1081,11 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.Tracing (4.3) - restriction: >= netcoreapp2.1
+    System.Diagnostics.Tracing (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Dynamic.Runtime (4.3) - restriction: >= netcoreapp2.1
+    System.Dynamic.Runtime (4.3) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Linq (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1104,30 +1104,30 @@ NUGET
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Globalization.Calendars (4.3) - restriction: >= netcoreapp2.1
+    System.Globalization.Calendars (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Globalization.Extensions (4.3) - restriction: >= netcoreapp2.1
+    System.Globalization.Extensions (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.IdentityModel.Tokens.Jwt (5.3) - restriction: >= netcoreapp2.1
+    System.IdentityModel.Tokens.Jwt (5.3) - restriction: >= netcoreapp3.0
       Microsoft.IdentityModel.JsonWebTokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    System.Interactive.Async (3.2) - restriction: >= netcoreapp2.1
+    System.Interactive.Async (3.2) - restriction: >= netcoreapp3.0
     System.IO (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.IO.Compression (4.3) - restriction: >= netcoreapp2.1
+    System.IO.Compression (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.IO.Compression (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1161,7 +1161,7 @@ NUGET
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.6) (< win8) (< wp8) (< wpa81))
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Linq.Expressions (4.3) - restriction: >= netcoreapp2.1
+    System.Linq.Expressions (4.3) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1179,7 +1179,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Linq.Queryable (4.3) - restriction: >= netcoreapp2.1
+    System.Linq.Queryable (4.3) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Linq (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -1188,8 +1188,8 @@ NUGET
       System.Reflection.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Memory (4.5.1) - restriction: >= netcoreapp2.1
-    System.Net.Http (4.3.4) - restriction: >= netcoreapp2.1
+    System.Memory (4.5.1) - restriction: >= netcoreapp3.0
+    System.Net.Http (4.3.4) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Net.Http (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1216,14 +1216,14 @@ NUGET
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-    System.Net.Primitives (4.3) - restriction: >= netcoreapp2.1
+    System.Net.Primitives (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       System.Runtime.Handles (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Net.WebSockets.WebSocketProtocol (4.5.2) - restriction: >= netcoreapp2.1
-    System.Numerics.Vectors (4.5) - restriction: >= netcoreapp2.1
-    System.ObjectModel (4.3) - restriction: >= netcoreapp2.1
+    System.Net.WebSockets.WebSocketProtocol (4.5.2) - restriction: >= netcoreapp3.0
+    System.Numerics.Vectors (4.5) - restriction: >= netcoreapp3.0
+    System.ObjectModel (4.3) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1261,7 +1261,7 @@ NUGET
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Reflection.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Reflection.Emit (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp2.1)
+    System.Reflection.Emit (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.0)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1296,7 +1296,7 @@ NUGET
     System.Runtime (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= net461) (< netstandard1.6)) (&& (< net45) (>= net461) (< netstandard2.0)) (&& (< net45) (>= net47)) (&& (>= net461) (>= netcoreapp1.1)) (>= netcoreapp1.0) (&& (>= netcoreapp1.1) (>= netstandard2.0))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Runtime.CompilerServices.Unsafe (4.5.2) - restriction: >= netcoreapp2.1
+    System.Runtime.CompilerServices.Unsafe (4.5.2) - restriction: >= netcoreapp3.0
     System.Runtime.Extensions (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
@@ -1317,7 +1317,7 @@ NUGET
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Runtime.Numerics (4.3) - restriction: >= netcoreapp2.1
+    System.Runtime.Numerics (4.3) - restriction: >= netcoreapp3.0
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
@@ -1329,17 +1329,17 @@ NUGET
     System.Runtime.Serialization.Primitives (4.3) - restriction: >= netcoreapp1.0
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Runtime.Serialization.Xml (4.3) - restriction: >= netcoreapp2.1
+    System.Runtime.Serialization.Xml (4.3) - restriction: >= netcoreapp3.0
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Private.DataContractSerialization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime.Serialization.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Xml.ReaderWriter (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Security.AccessControl (4.5) - restriction: >= netcoreapp2.1
+    System.Security.AccessControl (4.5) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: || (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0)
-    System.Security.Claims (4.3) - restriction: >= netcoreapp2.1
+    System.Security.Claims (4.3) - restriction: >= netcoreapp3.0
       System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1347,7 +1347,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Security.Principal (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.Algorithms (4.3.1) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.Algorithms (4.3.1) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       runtime.native.System.Security.Cryptography.Apple (>= 4.3.1) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.2) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1362,8 +1362,8 @@ NUGET
       System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net463)
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net46) (< netstandard1.4)) (&& (>= net461) (< netstandard1.6)) (>= net463)
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Cryptography.Cng (4.5) - restriction: >= netcoreapp2.1
-    System.Security.Cryptography.Csp (4.3) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.Cng (4.5) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Csp (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1377,7 +1377,7 @@ NUGET
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.Encoding (4.3) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.Encoding (4.3) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1390,10 +1390,10 @@ NUGET
       System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.OpenSsl (4.5) - restriction: >= netcoreapp2.1
-    System.Security.Cryptography.Pkcs (4.5.1) - restriction: >= netcoreapp2.1
-      System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netcoreapp2.1
-    System.Security.Cryptography.Primitives (4.3) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.OpenSsl (4.5) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Pkcs (4.5.1) - restriction: >= netcoreapp3.0
+      System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Primitives (4.3) - restriction: >= netcoreapp3.0
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1401,7 +1401,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.X509Certificates (4.3.2) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.X509Certificates (4.3.2) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       runtime.native.System (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Net.Http (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1427,20 +1427,20 @@ NUGET
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Cryptography.Xml (4.5) - restriction: >= netcoreapp2.1
+    System.Security.Cryptography.Xml (4.5) - restriction: >= netcoreapp3.0
       System.Security.Cryptography.Pkcs (>= 4.5) - restriction: && (< net461) (>= netstandard2.0)
       System.Security.Permissions (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Security.Permissions (4.5) - restriction: >= netcoreapp2.1
+    System.Security.Permissions (4.5) - restriction: >= netcoreapp3.0
       System.Security.AccessControl (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Security.Principal (4.3) - restriction: >= netcoreapp2.1
+    System.Security.Principal (4.3) - restriction: >= netcoreapp3.0
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Principal.Windows (4.5.1) - restriction: >= netcoreapp2.1
+    System.Security.Principal.Windows (4.5.1) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
     System.Text.Encoding (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5)) (&& (< net45) (>= net461) (< netstandard1.5)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Text.Encoding.CodePages (4.5) - restriction: >= netcoreapp2.1
+    System.Text.Encoding.CodePages (4.5) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: || (&& (< net46) (>= netstandard2.0) (< xamarinios)) (>= net461) (>= netcoreapp2.0)
     System.Text.Encoding.Extensions (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
@@ -1448,7 +1448,7 @@ NUGET
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Text.Encodings.Web (4.5) - restriction: >= netcoreapp2.1
+    System.Text.Encodings.Web (4.5) - restriction: >= netcoreapp3.0
     System.Text.RegularExpressions (4.3) - restriction: || (>= net461) (>= netcoreapp1.0) (>= netstandard2.0)
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1459,13 +1459,13 @@ NUGET
     System.Threading (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Threading.Channels (4.5) - restriction: >= netcoreapp2.1
+    System.Threading.Channels (4.5) - restriction: >= netcoreapp3.0
     System.Threading.Tasks (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5)) (&& (< net45) (>= net461) (< netstandard1.5)) (&& (< net45) (>= net461) (>= netstandard1.6)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Threading.Tasks.Extensions (4.5.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp2.1)
-    System.Threading.Tasks.Parallel (4.3) - restriction: >= netcoreapp2.1
+    System.Threading.Tasks.Extensions (4.5.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.0)
+    System.Threading.Tasks.Parallel (4.3) - restriction: >= netcoreapp3.0
       System.Collections.Concurrent (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Tracing (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1479,7 +1479,7 @@ NUGET
     System.Threading.ThreadPool (4.3) - restriction: >= netcoreapp1.0
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Handles (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.ValueTuple (4.5) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.6) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.1)
+    System.ValueTuple (4.5) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.6) (>= netstandard2.0)) (>= net461) (>= netcoreapp3.0)
     System.Xml.ReaderWriter (4.3.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1548,7 +1548,7 @@ NUGET
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Xml.ReaderWriter (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Xml.XPath.XDocument (4.3) - restriction: >= netcoreapp2.1
+    System.Xml.XPath.XDocument (4.3) - restriction: >= netcoreapp3.0
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Linq (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)

--- a/src/content/Razor/paket.lock
+++ b/src/content/Razor/paket.lock
@@ -25,10 +25,10 @@ NUGET
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       System.ValueTuple (>= 4.4) - restriction: >= net461
       TaskBuilder.fs (>= 2.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNet.WebApi.Client (5.2.6) - restriction: >= netcoreapp3.0
+    Microsoft.AspNet.WebApi.Client (5.2.6) - restriction: >= netcoreapp3.1
       Newtonsoft.Json (>= 10.0.1) - restriction: && (< net45) (>= netstandard2.0)
       Newtonsoft.Json.Bson (>= 1.0.1) - restriction: && (< net45) (>= netstandard2.0)
-    Microsoft.AspNetCore (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Diagnostics (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.HostFiltering (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
@@ -52,151 +52,151 @@ NUGET
       Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.App (2.1.5)
-      Microsoft.AspNet.WebApi.Client (>= 5.2.6 < 5.3) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Antiforgery (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Facebook (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Google (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.JwtBearer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.MicrosoftAccount (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.OpenIdConnect (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.Twitter (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authentication.WsFederation (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authorization (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Authorization.Policy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.CookiePolicy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Cors (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.DataProtection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.DataProtection.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Diagnostics (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.HostFiltering (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Connections (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Connections.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Http.Features (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.HttpOverrides (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.HttpsPolicy (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Identity (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Identity.EntityFrameworkCore (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Identity.UI (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.JsonPatch (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Localization.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.MiddlewareAnalysis (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Analyzers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Formatters.Xml (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Localization (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.NodeServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Owin (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Razor.Design (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Razor.Language (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Razor.Runtime (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.ResponseCaching (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.ResponseCompression (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Rewrite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.HttpSys (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.IISIntegration (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.Kestrel (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.Session (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SignalR (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SignalR.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SignalR.Core (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SpaServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.SpaServices.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.StaticFiles (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.WebSockets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.AspNetCore.WebUtilities (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.CodeAnalysis.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Design (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.InMemory (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Relational (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.SqlServer (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.EntityFrameworkCore.Tools (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Caching.Abstractions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Caching.Memory (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Caching.SqlServer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Binder (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.CommandLine (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Ini (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Json (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.KeyPerFile (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.UserSecrets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Configuration.Xml (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.DependencyInjection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.DiagnosticAdapter (>= 2.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileProviders.Composite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Identity.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Identity.Stores (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Localization.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.Console (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.Debug (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.EventSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Logging.TraceSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.ObjectPool (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Options (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.Primitives (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Extensions.WebEncoders (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      Microsoft.Net.Http.Headers (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.0
-      System.IO.Pipelines (>= 4.5.2) - restriction: >= netcoreapp3.0
+      Microsoft.AspNet.WebApi.Client (>= 5.2.6 < 5.3) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Antiforgery (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.Facebook (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.Google (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.JwtBearer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.MicrosoftAccount (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.OpenIdConnect (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.Twitter (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authentication.WsFederation (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authorization (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Authorization.Policy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.CookiePolicy (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Cors (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.DataProtection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.DataProtection.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Diagnostics (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.HostFiltering (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Http.Connections (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Http.Connections.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Http.Features (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.HttpOverrides (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.HttpsPolicy (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Identity (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Identity.EntityFrameworkCore (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Identity.UI (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.JsonPatch (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Localization.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.MiddlewareAnalysis (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Analyzers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Cors (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Formatters.Xml (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Localization (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.NodeServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Owin (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Razor.Design (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Razor.Language (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Razor.Runtime (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.ResponseCaching (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.ResponseCompression (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Rewrite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Routing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.HttpSys (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.IISIntegration (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.Kestrel (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.Session (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.SignalR (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.SignalR.Common (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.SignalR.Core (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4 < 1.1) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.SpaServices (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.SpaServices.Extensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.StaticFiles (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.WebSockets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.AspNetCore.WebUtilities (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.CodeAnalysis.Razor (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.Design (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.InMemory (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.Relational (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.SqlServer (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.EntityFrameworkCore.Tools (>= 2.1.4 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Caching.Abstractions (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Caching.Memory (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Caching.SqlServer (>= 2.1.2 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.Binder (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.CommandLine (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.Ini (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.Json (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.KeyPerFile (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.UserSecrets (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Configuration.Xml (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.DependencyInjection (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.DiagnosticAdapter (>= 2.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.FileProviders.Composite (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Hosting (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Http (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Identity.Core (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Identity.Stores (>= 2.1.3 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Localization (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Localization.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging.Configuration (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging.Console (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging.Debug (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging.EventSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Logging.TraceSource (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.ObjectPool (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Options (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.Primitives (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Extensions.WebEncoders (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      Microsoft.Net.Http.Headers (>= 2.1.1 < 2.2) - restriction: >= netcoreapp3.1
+      System.IO.Pipelines (>= 4.5.2) - restriction: >= netcoreapp3.1
     Microsoft.AspNetCore.Authentication (2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
@@ -205,60 +205,60 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.WebEncoders (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Cookies (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.Cookies (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Core (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.Core (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Facebook (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.Facebook (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Google (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.Google (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.JwtBearer (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.JwtBearer (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.OpenIdConnect (>= 5.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.MicrosoftAccount (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.MicrosoftAccount (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.OAuth (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.OAuth (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.OpenIdConnect (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.OpenIdConnect (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.OpenIdConnect (>= 5.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Twitter (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.Twitter (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.OAuth (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.WsFederation (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authentication.WsFederation (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.IdentityModel.Protocols.WsFederation (>= 5.2) - restriction: >= netstandard2.0
       System.IdentityModel.Tokens.Jwt (>= 5.2) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.Authorization (2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authorization.Policy (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Authorization.Policy (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Authorization (>= 2.1.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Connections.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Connections.Abstractions (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       System.IO.Pipelines (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.CookiePolicy (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.CookiePolicy (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cors (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Cors (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cryptography.Internal (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Cryptography.KeyDerivation (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Cryptography.Internal (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.AspNetCore.Cryptography.KeyDerivation (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.DataProtection (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.DataProtection (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -268,8 +268,8 @@ NUGET
       Microsoft.Win32.Registry (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Cryptography.Xml (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.DataProtection.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.DataProtection.Extensions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.DataProtection.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.AspNetCore.DataProtection.Extensions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.Diagnostics (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -282,11 +282,11 @@ NUGET
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
       System.Reflection.Metadata (>= 1.6) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Diagnostics.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Diagnostics.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HostFiltering (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.HostFiltering (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -309,21 +309,21 @@ NUGET
       Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Html.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Html.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Http (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Http.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Connections (1.0.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Http.Connections (1.0.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authorization.Policy (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
@@ -331,54 +331,54 @@ NUGET
       Microsoft.AspNetCore.Routing (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebSockets (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Connections.Common (1.0.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Http.Connections.Common (1.0.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Extensions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Http.Extensions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Features (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Http.Features (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HttpOverrides (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.HttpOverrides (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HttpsPolicy (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.HttpsPolicy (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Identity (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.Cookies (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity.EntityFrameworkCore (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Identity.EntityFrameworkCore (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Identity (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Stores (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Identity.UI (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Identity.UI (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Identity (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.StaticFiles (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Embedded (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Identity.Stores (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.JsonPatch (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.JsonPatch (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.CSharp (>= 4.5) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Localization (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Localization (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Localization.Routing (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Localization.Routing (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.MiddlewareAnalysis (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.MiddlewareAnalysis (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
@@ -395,13 +395,13 @@ NUGET
       Microsoft.AspNetCore.Razor.Design (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Abstractions (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Analyzers (2.1.3) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Mvc.ApiExplorer (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Analyzers (2.1.3) - restriction: >= netcoreapp3.1
+    Microsoft.AspNetCore.Mvc.ApiExplorer (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Core (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Core (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Authorization.Policy (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -416,24 +416,24 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5.1) - restriction: >= netstandard2.0
       System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Cors (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Cors (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Cors (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.DataAnnotations (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.DataAnnotations (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Formatters.Json (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Formatters.Json (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.JsonPatch (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Formatters.Xml (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Formatters.Xml (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Localization (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Localization (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Razor (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Razor (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.3) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Razor.Runtime (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -441,22 +441,22 @@ NUGET
       Microsoft.CodeAnalysis.Razor (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.FileProviders.Composite (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNetCore.Mvc.Razor.Extensions (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Razor.Extensions (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Razor.Language (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.Razor (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
-    Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.Razor.ViewCompilation (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: || (>= net461) (>= netcoreapp2.0)
       Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.1) - restriction: || (>= net461) (>= netcoreapp2.0)
-    Microsoft.AspNetCore.Mvc.RazorPages (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.RazorPages (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.TagHelpers (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.TagHelpers (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.Razor (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Razor.Runtime (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.ViewFeatures (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Mvc.ViewFeatures (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Antiforgery (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -465,17 +465,17 @@ NUGET
       Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.WebEncoders (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json.Bson (>= 1.0.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.NodeServices (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.NodeServices (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Console (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Owin (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Owin (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Razor (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor.Design (2.1.2) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Razor.Language (2.1.2) - restriction: >= netcoreapp3.0
-    Microsoft.AspNetCore.Razor.Runtime (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Razor.Design (2.1.2) - restriction: >= netcoreapp3.1
+    Microsoft.AspNetCore.Razor.Language (2.1.2) - restriction: >= netcoreapp3.1
+    Microsoft.AspNetCore.Razor.Runtime (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Razor (>= 2.1.2) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.ResponseCaching (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
@@ -484,33 +484,33 @@ NUGET
       Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCompression (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.ResponseCompression (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNetCore.Rewrite (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Rewrite (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Routing (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Routing (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Routing.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Routing.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.HttpSys (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.HttpSys (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Win32.Registry (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.IISIntegration (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.IISIntegration (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
@@ -524,12 +524,12 @@ NUGET
       System.Numerics.Vectors (>= 4.5) - restriction: >= netstandard2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5.2) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.Kestrel (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Core (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.Kestrel.Core (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
@@ -542,30 +542,30 @@ NUGET
       System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
       System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netstandard2.0
       System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Https (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.Kestrel.Https (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Session (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.Session (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR (1.0.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.SignalR (1.0.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Connections (>= 1.0.4) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Core (>= 1.0.4) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Common (1.0.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.SignalR.Common (1.0.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Core (1.0.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.SignalR.Core (1.0.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Authorization (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Common (>= 1.0.4) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.SignalR.Protocols.Json (>= 1.0.4) - restriction: >= netstandard2.0
@@ -573,19 +573,19 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Reflection.Emit (>= 4.3) - restriction: >= netstandard2.0
       System.Threading.Channels (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SignalR.Protocols.Json (1.0.4) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.SignalR.Protocols.Json (1.0.4) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.SignalR.Common (>= 1.0.4) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SpaServices (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.SpaServices (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.NodeServices (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.SpaServices.Extensions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.SpaServices.Extensions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.SpaServices (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.StaticFiles (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.WebSockets (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.StaticFiles (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.StaticFiles (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -594,15 +594,15 @@ NUGET
     Microsoft.AspNetCore.TestHost (2.1.1)
       Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
       System.IO.Pipelines (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.WebSockets (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.WebSockets (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Net.WebSockets.WebSocketProtocol (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.WebUtilities (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.AspNetCore.WebUtilities (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.CodeAnalysis.Analyzers (2.6.2) - restriction: >= netcoreapp3.0
-    Microsoft.CodeAnalysis.Common (2.9) - restriction: >= netcoreapp3.0
+    Microsoft.CodeAnalysis.Analyzers (2.6.2) - restriction: >= netcoreapp3.1
+    Microsoft.CodeAnalysis.Common (2.9) - restriction: >= netcoreapp3.1
       Microsoft.CodeAnalysis.Analyzers (>= 2.6.1) - restriction: >= netstandard1.3
       System.AppContext (>= 4.3) - restriction: >= netstandard1.3
       System.Collections (>= 4.3) - restriction: >= netstandard1.3
@@ -643,15 +643,15 @@ NUGET
       System.Xml.XDocument (>= 4.3) - restriction: >= netstandard1.3
       System.Xml.XmlDocument (>= 4.3) - restriction: >= netstandard1.3
       System.Xml.XPath.XDocument (>= 4.3) - restriction: >= netstandard1.3
-    Microsoft.CodeAnalysis.CSharp (2.9) - restriction: >= netcoreapp3.0
+    Microsoft.CodeAnalysis.CSharp (2.9) - restriction: >= netcoreapp3.1
       Microsoft.CodeAnalysis.Common (2.9)
-    Microsoft.CodeAnalysis.Razor (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.CodeAnalysis.Razor (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Razor.Language (>= 2.1.2) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.Common (>= 2.8) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.CSharp (>= 2.8) - restriction: || (>= net46) (>= netstandard2.0)
     Microsoft.CodeCoverage (15.9) - restriction: || (>= net45) (>= netcoreapp1.0)
-    Microsoft.CSharp (4.5) - restriction: >= netcoreapp3.0
-    Microsoft.DotNet.PlatformAbstractions (2.1) - restriction: >= netcoreapp3.0
+    Microsoft.CSharp (4.5) - restriction: >= netcoreapp3.1
+    Microsoft.DotNet.PlatformAbstractions (2.1) - restriction: >= netcoreapp3.1
       System.AppContext (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Collections (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.3)
       System.IO (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
@@ -660,7 +660,7 @@ NUGET
       System.Runtime.Extensions (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Runtime.InteropServices (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Runtime.InteropServices.RuntimeInformation (>= 4.0) - restriction: || (>= net45) (>= netstandard1.3)
-    Microsoft.EntityFrameworkCore (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.EntityFrameworkCore.Abstractions (>= 2.1.4) - restriction: >= netstandard2.0
       Microsoft.EntityFrameworkCore.Analyzers (>= 2.1.4) - restriction: >= netstandard2.0
       Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
@@ -671,135 +671,135 @@ NUGET
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5.1) - restriction: >= netstandard2.0
       System.Interactive.Async (>= 3.1.1) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Abstractions (2.1.4) - restriction: >= netcoreapp3.0
-    Microsoft.EntityFrameworkCore.Analyzers (2.1.4) - restriction: >= netcoreapp3.0
-    Microsoft.EntityFrameworkCore.Design (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.Abstractions (2.1.4) - restriction: >= netcoreapp3.1
+    Microsoft.EntityFrameworkCore.Analyzers (2.1.4) - restriction: >= netcoreapp3.1
+    Microsoft.EntityFrameworkCore.Design (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.CSharp (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.4) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.EntityFrameworkCore.InMemory (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.InMemory (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.EntityFrameworkCore (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Relational (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.Relational (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.EntityFrameworkCore (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.SqlServer (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.SqlServer (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.EntityFrameworkCore.Relational (>= 2.1.4) - restriction: >= netstandard2.0
       System.Data.SqlClient (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.EntityFrameworkCore.Tools (2.1.4) - restriction: >= netcoreapp3.0
+    Microsoft.EntityFrameworkCore.Tools (2.1.4) - restriction: >= netcoreapp3.1
       Microsoft.EntityFrameworkCore.Design (>= 2.1.4) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.Abstractions (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Caching.Abstractions (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.Memory (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Caching.Memory (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.SqlServer (2.1.2) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Caching.SqlServer (2.1.2) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Caching.Abstractions (>= 2.1.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Data.SqlClient (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Binder (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.Binder (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.CommandLine (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.CommandLine (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.EnvironmentVariables (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.EnvironmentVariables (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.FileExtensions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.FileExtensions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Ini (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.Ini (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Json (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.Json (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.KeyPerFile (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.KeyPerFile (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.UserSecrets (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.UserSecrets (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration.Json (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Xml (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Configuration.Xml (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Security.Cryptography.Xml (>= 4.5) - restriction: >= netstandard2.0
     Microsoft.Extensions.DependencyInjection (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.DependencyInjection.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.DependencyInjection.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
     Microsoft.Extensions.DependencyModel (2.1) - restriction: >= netcoreapp1.0
       Microsoft.DotNet.PlatformAbstractions (>= 2.1) - restriction: || (>= net451) (>= netstandard1.3)
       Newtonsoft.Json (>= 9.0.1) - restriction: || (>= net451) (>= netstandard1.3)
       System.Diagnostics.Debug (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
       System.Dynamic.Runtime (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
       System.Linq (>= 4.1) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
-    Microsoft.Extensions.DiagnosticAdapter (2.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.DiagnosticAdapter (2.1) - restriction: >= netcoreapp3.1
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.FileProviders.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.FileProviders.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Composite (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.FileProviders.Composite (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Embedded (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.FileProviders.Embedded (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
     Microsoft.Extensions.FileProviders.Physical (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileSystemGlobbing (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.Extensions.Hosting (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.FileSystemGlobbing (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.Extensions.Hosting (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Hosting.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Hosting.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Http (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Http (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Identity.Core (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Identity.Core (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.AspNetCore.Cryptography.KeyDerivation (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Identity.Stores (2.1.3) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Identity.Stores (2.1.3) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Identity.Core (>= 2.1.3) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Localization (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Localization (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Localization.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Localization.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.Extensions.Logging (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Localization.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.Extensions.Logging (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Abstractions (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.Extensions.Logging.Configuration (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging.Abstractions (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.Extensions.Logging.Configuration (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Console (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging.Console (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Debug (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging.Debug (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.EventSource (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging.EventSource (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.TraceSource (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Logging.TraceSource (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.ObjectPool (2.1.1) - restriction: >= netcoreapp3.0
-    Microsoft.Extensions.Options (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.ObjectPool (2.1.1) - restriction: >= netcoreapp3.1
+    Microsoft.Extensions.Options (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Options.ConfigurationExtensions (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.Options.ConfigurationExtensions (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
@@ -807,35 +807,35 @@ NUGET
     Microsoft.Extensions.Primitives (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       System.Memory (>= 4.5.1) - restriction: >= netstandard2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.WebEncoders (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Extensions.WebEncoders (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.IdentityModel.JsonWebTokens (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.JsonWebTokens (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Logging (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Logging (5.3) - restriction: >= netcoreapp3.1
       System.Diagnostics.Tracing (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Globalization (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IO (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IO.FileSystem (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Protocols (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Protocols (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Logging (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Collections.Specialized (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Diagnostics.Contracts (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Net.Http (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Protocols.OpenIdConnect (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Protocols.OpenIdConnect (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Protocols (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Dynamic.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.IdentityModel.Tokens.Jwt (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Protocols.WsFederation (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Protocols.WsFederation (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Protocols (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens.Saml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Xml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Xml.XmlDocument (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Tokens (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Tokens (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Logging (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       System.Collections (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
@@ -851,12 +851,12 @@ NUGET
       System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Text.RegularExpressions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
       System.Threading (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0))
-    Microsoft.IdentityModel.Tokens.Saml (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Tokens.Saml (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Xml (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.IdentityModel.Xml (5.3) - restriction: >= netcoreapp3.0
+    Microsoft.IdentityModel.Xml (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    Microsoft.Net.Http.Headers (2.1.1) - restriction: >= netcoreapp3.0
+    Microsoft.Net.Http.Headers (2.1.1) - restriction: >= netcoreapp3.1
       Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
     Microsoft.NET.Test.Sdk (15.9)
@@ -897,10 +897,10 @@ NUGET
     NETStandard.Library (2.0.3) - restriction: || (&& (< net35) (>= netstandard1.1) (< netstandard2.0)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= netstandard2.0)) (&& (< net452) (>= netstandard1.1)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (>= net45) (< netstandard1.3)) (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.4)) (>= net461) (>= netcoreapp2.0) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8) (< win8)) (&& (< netstandard1.0) (< portable-net45+win8) (>= portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard1.3) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= uap10.0)) (>= uap10.1) (>= wp8)
     Newtonsoft.Json (11.0.2) - restriction: || (>= net461) (>= netcoreapp1.0) (>= netstandard2.0) (>= uap10.0)
-    Newtonsoft.Json.Bson (1.0.1) - restriction: >= netcoreapp3.0
+    Newtonsoft.Json.Bson (1.0.1) - restriction: >= netcoreapp3.1
       NETStandard.Library (>= 1.6.1) - restriction: && (< net45) (>= netstandard1.3)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (>= net45) (>= netstandard1.3)
-    Remotion.Linq (2.2) - restriction: >= netcoreapp3.0
+    Remotion.Linq (2.2) - restriction: >= netcoreapp3.1
       System.Collections (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
       System.Diagnostics.Debug (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
       System.Linq (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
@@ -912,28 +912,28 @@ NUGET
       System.Runtime (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
       System.Runtime.Extensions (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
       System.Threading (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
-    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
     runtime.native.System (4.3.1) - restriction: >= netcoreapp1.0
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Data.SqlClient.sni (4.5) - restriction: >= netcoreapp3.0
+    runtime.native.System.Data.SqlClient.sni (4.5) - restriction: >= netcoreapp3.1
       runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (>= 4.4)
       runtime.win-x64.runtime.native.System.Data.SqlClient.sni (>= 4.4)
       runtime.win-x86.runtime.native.System.Data.SqlClient.sni (>= 4.4)
-    runtime.native.System.IO.Compression (4.3.2) - restriction: >= netcoreapp3.0
+    runtime.native.System.IO.Compression (4.3.2) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Net.Http (4.3.1) - restriction: >= netcoreapp3.0
+    runtime.native.System.Net.Http (4.3.1) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.0
+    runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.1
       runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (>= 4.3.1)
-    runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
+    runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
       runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
@@ -949,22 +949,22 @@ NUGET
       runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.0
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.0
-    runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
-    runtime.win-x64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
-    runtime.win-x86.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.0
-    System.AppContext (4.3) - restriction: >= netcoreapp3.0
+    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: >= netcoreapp3.1
+    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: >= netcoreapp3.1
+    runtime.win-arm64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.1
+    runtime.win-x64.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.1
+    runtime.win-x86.runtime.native.System.Data.SqlClient.sni (4.4) - restriction: >= netcoreapp3.1
+    System.AppContext (4.3) - restriction: >= netcoreapp3.1
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Buffers (4.5) - restriction: >= netcoreapp3.0
+    System.Buffers (4.5) - restriction: >= netcoreapp3.1
     System.Collections (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -980,15 +980,15 @@ NUGET
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
-    System.Collections.Immutable (1.5) - restriction: >= netcoreapp3.0
-    System.Collections.NonGeneric (4.3) - restriction: >= netcoreapp3.0
+    System.Collections.Immutable (1.5) - restriction: >= netcoreapp3.1
+    System.Collections.NonGeneric (4.3) - restriction: >= netcoreapp3.1
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Collections.Specialized (4.3) - restriction: >= netcoreapp3.0
+    System.Collections.Specialized (4.3) - restriction: >= netcoreapp3.1
       System.Collections.NonGeneric (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -996,7 +996,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.ComponentModel.Annotations (4.5) - restriction: >= netcoreapp3.0
+    System.ComponentModel.Annotations (4.5) - restriction: >= netcoreapp3.1
     System.ComponentModel.EventBasedAsync (4.3) - restriction: >= netcoreapp1.0
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -1005,25 +1005,25 @@ NUGET
     System.ComponentModel.Primitives (4.3) - restriction: >= uap10.0
     System.ComponentModel.TypeConverter (4.3) - restriction: || (>= netcoreapp1.0) (>= uap10.0)
       System.ComponentModel.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.5) (< win8)) (&& (>= net45) (< netstandard1.5)) (>= net462) (&& (< netstandard1.0) (>= win8)) (>= wp8) (>= wpa81)
-    System.Console (4.3.1) - restriction: >= netcoreapp3.0
+    System.Console (4.3.1) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1.2) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Data.SqlClient (4.5.1) - restriction: >= netcoreapp3.0
+    System.Data.SqlClient (4.5.1) - restriction: >= netcoreapp3.1
       Microsoft.Win32.Registry (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       runtime.native.System.Data.SqlClient.sni (>= 4.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net451) (>= netstandard1.3) (< netstandard2.0) (< win81) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       System.Security.Principal.Windows (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
       System.Text.Encoding.CodePages (>= 4.5) - restriction: || (&& (< net451) (>= netstandard2.0) (< xamarinios)) (>= netcoreapp2.0)
-    System.Diagnostics.Contracts (4.3) - restriction: >= netcoreapp3.0
+    System.Diagnostics.Contracts (4.3) - restriction: >= netcoreapp3.1
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
     System.Diagnostics.Debug (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (>= netstandard1.6)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Diagnostics.DiagnosticSource (4.5.1) - restriction: >= netcoreapp3.0
-    System.Diagnostics.FileVersionInfo (4.3) - restriction: >= netcoreapp3.0
+    System.Diagnostics.DiagnosticSource (4.5.1) - restriction: >= netcoreapp3.1
+    System.Diagnostics.FileVersionInfo (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1055,7 +1055,7 @@ NUGET
       System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.Thread (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.ThreadPool (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.StackTrace (4.3) - restriction: >= netcoreapp3.0
+    System.Diagnostics.StackTrace (4.3) - restriction: >= netcoreapp3.1
       System.IO.FileSystem (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection.Metadata (>= 1.4.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1067,7 +1067,7 @@ NUGET
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.Tools (4.3) - restriction: >= netcoreapp3.0
+    System.Diagnostics.Tools (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1081,11 +1081,11 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.Tracing (4.3) - restriction: >= netcoreapp3.0
+    System.Diagnostics.Tracing (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Dynamic.Runtime (4.3) - restriction: >= netcoreapp3.0
+    System.Dynamic.Runtime (4.3) - restriction: >= netcoreapp3.1
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Linq (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1104,30 +1104,30 @@ NUGET
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Globalization.Calendars (4.3) - restriction: >= netcoreapp3.0
+    System.Globalization.Calendars (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Globalization.Extensions (4.3) - restriction: >= netcoreapp3.0
+    System.Globalization.Extensions (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.IdentityModel.Tokens.Jwt (5.3) - restriction: >= netcoreapp3.0
+    System.IdentityModel.Tokens.Jwt (5.3) - restriction: >= netcoreapp3.1
       Microsoft.IdentityModel.JsonWebTokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Microsoft.IdentityModel.Tokens (>= 5.3) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
       Newtonsoft.Json (>= 10.0.1) - restriction: || (&& (>= net45) (< net451) (< netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net451) (< netstandard1.4)) (>= net461)
-    System.Interactive.Async (3.2) - restriction: >= netcoreapp3.0
+    System.Interactive.Async (3.2) - restriction: >= netcoreapp3.1
     System.IO (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.IO.Compression (4.3) - restriction: >= netcoreapp3.0
+    System.IO.Compression (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.IO.Compression (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1161,7 +1161,7 @@ NUGET
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.6) (< win8) (< wp8) (< wpa81))
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Linq.Expressions (4.3) - restriction: >= netcoreapp3.0
+    System.Linq.Expressions (4.3) - restriction: >= netcoreapp3.1
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1179,7 +1179,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Linq.Queryable (4.3) - restriction: >= netcoreapp3.0
+    System.Linq.Queryable (4.3) - restriction: >= netcoreapp3.1
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Linq (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -1188,8 +1188,8 @@ NUGET
       System.Reflection.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Memory (4.5.1) - restriction: >= netcoreapp3.0
-    System.Net.Http (4.3.4) - restriction: >= netcoreapp3.0
+    System.Memory (4.5.1) - restriction: >= netcoreapp3.1
+    System.Net.Http (4.3.4) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Net.Http (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1216,14 +1216,14 @@ NUGET
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-    System.Net.Primitives (4.3) - restriction: >= netcoreapp3.0
+    System.Net.Primitives (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
       System.Runtime.Handles (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Net.WebSockets.WebSocketProtocol (4.5.2) - restriction: >= netcoreapp3.0
-    System.Numerics.Vectors (4.5) - restriction: >= netcoreapp3.0
-    System.ObjectModel (4.3) - restriction: >= netcoreapp3.0
+    System.Net.WebSockets.WebSocketProtocol (4.5.2) - restriction: >= netcoreapp3.1
+    System.Numerics.Vectors (4.5) - restriction: >= netcoreapp3.1
+    System.ObjectModel (4.3) - restriction: >= netcoreapp3.1
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1261,7 +1261,7 @@ NUGET
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Reflection.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Reflection.Emit (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.0)
+    System.Reflection.Emit (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.1)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1296,7 +1296,7 @@ NUGET
     System.Runtime (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= net461) (< netstandard1.6)) (&& (< net45) (>= net461) (< netstandard2.0)) (&& (< net45) (>= net47)) (&& (>= net461) (>= netcoreapp1.1)) (>= netcoreapp1.0) (&& (>= netcoreapp1.1) (>= netstandard2.0))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
-    System.Runtime.CompilerServices.Unsafe (4.5.2) - restriction: >= netcoreapp3.0
+    System.Runtime.CompilerServices.Unsafe (4.5.2) - restriction: >= netcoreapp3.1
     System.Runtime.Extensions (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81))
@@ -1317,7 +1317,7 @@ NUGET
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Runtime.Numerics (4.3) - restriction: >= netcoreapp3.0
+    System.Runtime.Numerics (4.3) - restriction: >= netcoreapp3.1
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
@@ -1329,17 +1329,17 @@ NUGET
     System.Runtime.Serialization.Primitives (4.3) - restriction: >= netcoreapp1.0
       System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Runtime.Serialization.Xml (4.3) - restriction: >= netcoreapp3.0
+    System.Runtime.Serialization.Xml (4.3) - restriction: >= netcoreapp3.1
       System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Private.DataContractSerialization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime.Serialization.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Xml.ReaderWriter (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Security.AccessControl (4.5) - restriction: >= netcoreapp3.0
+    System.Security.AccessControl (4.5) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: || (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0)
-    System.Security.Claims (4.3) - restriction: >= netcoreapp3.0
+    System.Security.Claims (4.3) - restriction: >= netcoreapp3.1
       System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1347,7 +1347,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Security.Principal (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.Algorithms (4.3.1) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Algorithms (4.3.1) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       runtime.native.System.Security.Cryptography.Apple (>= 4.3.1) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.2) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1362,8 +1362,8 @@ NUGET
       System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net463)
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net46) (< netstandard1.4)) (&& (>= net461) (< netstandard1.6)) (>= net463)
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Cryptography.Cng (4.5) - restriction: >= netcoreapp3.0
-    System.Security.Cryptography.Csp (4.3) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Cng (4.5) - restriction: >= netcoreapp3.1
+    System.Security.Cryptography.Csp (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1377,7 +1377,7 @@ NUGET
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.Encoding (4.3) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Encoding (4.3) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1390,10 +1390,10 @@ NUGET
       System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.OpenSsl (4.5) - restriction: >= netcoreapp3.0
-    System.Security.Cryptography.Pkcs (4.5.1) - restriction: >= netcoreapp3.0
-      System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netcoreapp3.0
-    System.Security.Cryptography.Primitives (4.3) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.OpenSsl (4.5) - restriction: >= netcoreapp3.1
+    System.Security.Cryptography.Pkcs (4.5.1) - restriction: >= netcoreapp3.1
+      System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netcoreapp3.1
+    System.Security.Cryptography.Primitives (4.3) - restriction: >= netcoreapp3.1
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1401,7 +1401,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.X509Certificates (4.3.2) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.X509Certificates (4.3.2) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       runtime.native.System (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Net.Http (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1427,20 +1427,20 @@ NUGET
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Cryptography.Xml (4.5) - restriction: >= netcoreapp3.0
+    System.Security.Cryptography.Xml (4.5) - restriction: >= netcoreapp3.1
       System.Security.Cryptography.Pkcs (>= 4.5) - restriction: && (< net461) (>= netstandard2.0)
       System.Security.Permissions (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Security.Permissions (4.5) - restriction: >= netcoreapp3.0
+    System.Security.Permissions (4.5) - restriction: >= netcoreapp3.1
       System.Security.AccessControl (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Security.Principal (4.3) - restriction: >= netcoreapp3.0
+    System.Security.Principal (4.3) - restriction: >= netcoreapp3.1
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Security.Principal.Windows (4.5.1) - restriction: >= netcoreapp3.0
+    System.Security.Principal.Windows (4.5.1) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
     System.Text.Encoding (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5)) (&& (< net45) (>= net461) (< netstandard1.5)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Text.Encoding.CodePages (4.5) - restriction: >= netcoreapp3.0
+    System.Text.Encoding.CodePages (4.5) - restriction: >= netcoreapp3.1
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: || (&& (< net46) (>= netstandard2.0) (< xamarinios)) (>= net461) (>= netcoreapp2.0)
     System.Text.Encoding.Extensions (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
@@ -1448,7 +1448,7 @@ NUGET
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Text.Encodings.Web (4.5) - restriction: >= netcoreapp3.0
+    System.Text.Encodings.Web (4.5) - restriction: >= netcoreapp3.1
     System.Text.RegularExpressions (4.3) - restriction: || (>= net461) (>= netcoreapp1.0) (>= netstandard2.0)
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1459,13 +1459,13 @@ NUGET
     System.Threading (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Threading.Tasks (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Threading.Channels (4.5) - restriction: >= netcoreapp3.0
+    System.Threading.Channels (4.5) - restriction: >= netcoreapp3.1
     System.Threading.Tasks (4.3) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461) (< netstandard1.3)) (&& (< net45) (>= net461) (>= netstandard1.5)) (&& (< net45) (>= net461) (< netstandard1.5)) (&& (< net45) (>= net461) (>= netstandard1.6)) (>= netcoreapp1.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Threading.Tasks.Extensions (4.5.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.0)
-    System.Threading.Tasks.Parallel (4.3) - restriction: >= netcoreapp3.0
+    System.Threading.Tasks.Extensions (4.5.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (>= netcoreapp3.1)
+    System.Threading.Tasks.Parallel (4.3) - restriction: >= netcoreapp3.1
       System.Collections.Concurrent (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Tracing (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1479,7 +1479,7 @@ NUGET
     System.Threading.ThreadPool (4.3) - restriction: >= netcoreapp1.0
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.Handles (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.ValueTuple (4.5) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.6) (>= netstandard2.0)) (>= net461) (>= netcoreapp3.0)
+    System.ValueTuple (4.5) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.6) (>= netstandard2.0)) (>= net461) (>= netcoreapp3.1)
     System.Xml.ReaderWriter (4.3.1) - restriction: || (&& (>= dnxcore50) (>= net461)) (&& (>= dnxcore50) (>= netstandard2.0)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (>= netcoreapp1.0)
       System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -1548,7 +1548,7 @@ NUGET
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Xml.ReaderWriter (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Xml.XPath.XDocument (4.3) - restriction: >= netcoreapp3.0
+    System.Xml.XPath.XDocument (4.3) - restriction: >= netcoreapp3.1
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Linq (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)

--- a/src/content/Razor/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
+++ b/src/content/Razor/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>AppNamePlaceholder</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/content/Razor/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
+++ b/src/content/Razor/src/AppNamePlaceholder/AppNamePlaceholder.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>AppNamePlaceholder</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -9,8 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UsePaket)' == false OR '$(UsePaket)' == ''">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
-    <PackageReference Include="Giraffe" Version="3.4.*" />
+    <PackageReference Include="Giraffe" Version="4.0.*" />
     <PackageReference Include="Giraffe.Razor" Version="2.0.*" />
     <PackageReference Include="TaskBuilder.fs" Version="2.1.*" />
   </ItemGroup>

--- a/src/content/Razor/src/AppNamePlaceholder/Program.fs
+++ b/src/content/Razor/src/AppNamePlaceholder/Program.fs
@@ -48,10 +48,10 @@ let configureCors (builder : CorsPolicyBuilder) =
            |> ignore
 
 let configureApp (app : IApplicationBuilder) =
-    let env = app.ApplicationServices.GetService<IHostingEnvironment>()
-    (match env.IsDevelopment() with
-    | true  -> app.UseDeveloperExceptionPage()
-    | false -> app.UseGiraffeErrorHandler errorHandler)
+    let env = app.ApplicationServices.GetService<IWebHostEnvironment>()
+    (match env.EnvironmentName with
+    | "Development" -> app.UseDeveloperExceptionPage()
+    | _ -> app.UseGiraffeErrorHandler(errorHandler))
         .UseHttpsRedirection()
         .UseCors(configureCors)
         .UseStaticFiles()
@@ -59,7 +59,7 @@ let configureApp (app : IApplicationBuilder) =
 
 let configureServices (services : IServiceCollection) =
     let sp  = services.BuildServiceProvider()
-    let env = sp.GetService<IHostingEnvironment>()
+    let env = sp.GetService<IWebHostEnvironment>()
     let viewsFolderPath = Path.Combine(env.ContentRootPath, "Views")
     services.AddRazorEngine viewsFolderPath |> ignore
     services.AddCors() |> ignore

--- a/src/content/Razor/src/AppNamePlaceholder/paket.references
+++ b/src/content/Razor/src/AppNamePlaceholder/paket.references
@@ -1,3 +1,2 @@
-Microsoft.AspNetCore.App
 Giraffe
 Giraffe.Razor

--- a/src/content/Razor/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
+++ b/src/content/Razor/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
 

--- a/src/content/Razor/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
+++ b/src/content/Razor/tests/AppNamePlaceholder.Tests/AppNamePlaceholder.Tests.fsproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UsePaket)' == false OR '$(UsePaket)' == ''">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.*" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.*" />
     <PackageReference Include="xunit" Version="2.4.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.*" />
   </ItemGroup>


### PR DESCRIPTION
- Updated Giraffe to version 4.0.x
- Set .NET 3.1 LTS as Default
- Fix build warnings