### PR TITLE
Raised version of .fsproj files to .NET 6.0

### DIFF
--- a/src/content/DotLiquid/src/AppName.1/AppName.1.fsproj
+++ b/src/content/DotLiquid/src/AppName.1/AppName.1.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>AppName.1.App</AssemblyName>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
   </PropertyGroup>

--- a/src/content/DotLiquid/tests/AppName.1.Tests/AppName.1.Tests.fsproj
+++ b/src/content/DotLiquid/tests/AppName.1.Tests/AppName.1.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup Condition="'$(Paket)' == false OR '$(Paket)' == ''">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.*" />

--- a/src/content/Giraffe/src/AppName.1/AppName.1.fsproj
+++ b/src/content/Giraffe/src/AppName.1/AppName.1.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>AppName.1.App</AssemblyName>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
   </PropertyGroup>

--- a/src/content/Giraffe/tests/AppName.1.Tests/AppName.1.Tests.fsproj
+++ b/src/content/Giraffe/tests/AppName.1.Tests/AppName.1.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup Condition="'$(Paket)' == false OR '$(Paket)' == ''">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.*" />

--- a/src/content/None/src/AppName.1/AppName.1.fsproj
+++ b/src/content/None/src/AppName.1/AppName.1.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>AppName.1.App</AssemblyName>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
   </PropertyGroup>

--- a/src/content/None/tests/AppName.1.Tests/AppName.1.Tests.fsproj
+++ b/src/content/None/tests/AppName.1.Tests/AppName.1.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup Condition="'$(Paket)' == false OR '$(Paket)' == ''">
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.*" />

--- a/src/content/Razor/src/AppName.1/AppName.1.fsproj
+++ b/src/content/Razor/src/AppName.1/AppName.1.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>AppName.1.App</AssemblyName>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
   </PropertyGroup>

--- a/src/content/Razor/tests/AppName.1.Tests/AppName.1.Tests.fsproj
+++ b/src/content/Razor/tests/AppName.1.Tests/AppName.1.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
   <ItemGroup Condition="'$(Paket)' == false OR '$(Paket)' == ''">


### PR DESCRIPTION
After installing Giraffe and running dotnet run while having .NET 6+ I run to issue:
.NET 6: The framework 'Microsoft.AspNetCore.App', version '5.0.0' was not found
I had to change .NET version to 6.0 in .fsproj file.